### PR TITLE
fix(PipelinesRun): Only display re-run action when job is finished

### DIFF
--- a/src/pipelines/features/PipelineRunDataCard/PipelineRunDataCard.tsx
+++ b/src/pipelines/features/PipelineRunDataCard/PipelineRunDataCard.tsx
@@ -88,16 +88,18 @@ const PipelineRunDataCard = (props: PipelineRunDataCardProps) => {
                 </Button>
               </a>
             )}
-            <Link
-              href={{
-                pathname: "/pipelines/[pipelineId]/run",
-                query: { pipelineId: dag.id, fromRun: dagRun.id },
-              }}
-            >
-              <Button size="sm" leadingIcon={<PlayIcon className="w-5" />}>
-                {t("Re-run job")}
-              </Button>
-            </Link>
+            {isFinished && (
+              <Link
+                href={{
+                  pathname: "/pipelines/[pipelineId]/run",
+                  query: { pipelineId: dag.id, fromRun: dagRun.id },
+                }}
+              >
+                <Button size="sm" leadingIcon={<PlayIcon className="w-5" />}>
+                  {t("Re-run job")}
+                </Button>
+              </Link>
+            )}
             <PipelineRunFavoriteTrigger run={dagRun} />
           </div>
         )}


### PR DESCRIPTION
Re-run job action should only be displayed when the run is either failed or succeded.

## How/what to test

1. Trigger a pipeline run.
2. "Re-run job" should not be visible
3. When job is done, "re-run" is displayed

