### PR TITLE
fix(HeaderMenu) : render menuItem as anchor or button

### DIFF
--- a/src/core/components/Layout/Header.tsx
+++ b/src/core/components/Layout/Header.tsx
@@ -69,13 +69,9 @@ const Header = () => {
             />
           }
         >
-          <Menu.Item onClick={() => router.push("/user/account")}>
-            {t("Your account")}
-          </Menu.Item>
+          <Menu.Item linkTo="/user/account">{t("Your account")}</Menu.Item>
           {me.permissions.adminPanel && (
-            <Menu.Item onClick={() => router.push("/admin")}>
-              {t("Admin")}
-            </Menu.Item>
+            <Menu.Item linkTo="/admin">{t("Admin")}</Menu.Item>
           )}
 
           <Menu.Item onClick={() => logout()}>{t("Sign out")}</Menu.Item>

--- a/src/core/components/Layout/Header.tsx
+++ b/src/core/components/Layout/Header.tsx
@@ -69,9 +69,9 @@ const Header = () => {
             />
           }
         >
-          <Menu.Item linkTo="/user/account">{t("Your account")}</Menu.Item>
+          <Menu.Item href="/user/account">{t("Your account")}</Menu.Item>
           {me.permissions.adminPanel && (
-            <Menu.Item linkTo="/admin">{t("Admin")}</Menu.Item>
+            <Menu.Item href="/admin">{t("Admin")}</Menu.Item>
           )}
 
           <Menu.Item onClick={() => logout()}>{t("Sign out")}</Menu.Item>

--- a/src/core/components/Menu.tsx
+++ b/src/core/components/Menu.tsx
@@ -63,21 +63,29 @@ const Item = ({
   activeClassName = MenuClasses.ActiveItem,
   onClick,
   className = MenuClasses.Item,
+  linkTo,
 }: {
   children: ReactNode;
   onClick?: ((event: { preventDefault: Function }) => void) | undefined;
   className?: string;
   activeClassName?: string;
+  linkTo?: string;
 }) => (
   <HeadlessMenu.Item>
-    {({ active }) => (
-      <button
-        onClick={onClick}
-        className={clsx(className, active && activeClassName)}
-      >
-        {children}
-      </button>
-    )}
+    {({ active }) =>
+      onClick ? (
+        <button
+          onClick={onClick}
+          className={clsx(className, active && activeClassName)}
+        >
+          {children}
+        </button>
+      ) : (
+        <a href={linkTo} className={clsx(className, active && activeClassName)}>
+          {children}
+        </a>
+      )
+    }
   </HeadlessMenu.Item>
 );
 

--- a/src/core/components/Menu.tsx
+++ b/src/core/components/Menu.tsx
@@ -14,7 +14,7 @@ export const MenuClasses = {
     ButtonClasses.white,
     ButtonClasses.md
   ),
-  Item: "group flex px-2 py-2 items-center w-full text-sm rounded",
+  Item: "group flex px-2 py-2 items-center w-full text-sm rounded hover:bg-blue-500 hover:text-white",
   ActiveItem: "bg-blue-500 text-white",
   Items:
     "origin-top-right absolute right-0 mt-2 w-36 ring-1 ring-black ring-opacity-5 rounded shadow-lg bg-white text-gray-900 focus:outline-none text-right z-40 divide-y divide-gray-200 ",
@@ -59,37 +59,47 @@ const Menu = ({ label, trigger, className, children }: MenuProps) => {
   );
 };
 
+type ItemProps = {
+  children: ReactNode;
+  className?: string;
+  activeClassName?: string;
+} & (
+  | {
+      onClick: ((event: { preventDefault: Function }) => void) | undefined;
+      href?: never;
+    }
+  | { onClick?: never; href: string }
+);
+
 const Item = ({
   children,
   activeClassName = MenuClasses.ActiveItem,
   onClick,
   className = MenuClasses.Item,
-  href = "",
-}: {
-  children: ReactNode;
-  onClick?: ((event: { preventDefault: Function }) => void) | undefined;
-  className?: string;
-  activeClassName?: string;
-  href?: string;
-}) => (
+  href,
+}: ItemProps) => (
   <HeadlessMenu.Item>
-    {({ active }) =>
-      onClick ? (
-        <button
-          onClick={onClick}
-          className={clsx(className, active && activeClassName)}
-        >
-          {children}
-        </button>
-      ) : (
-        <Link
-          href={href}
-          className={clsx(className, active && activeClassName)}
-        >
-          {children}
-        </Link>
-      )
-    }
+    {({ active }) => (
+      <>
+        {onClick && (
+          <button
+            onClick={onClick}
+            className={clsx(className, active && activeClassName)}
+          >
+            {children}
+          </button>
+        )}
+
+        {href && (
+          <Link
+            href={href}
+            className={clsx(className, active && activeClassName)}
+          >
+            {children}
+          </Link>
+        )}
+      </>
+    )}
   </HeadlessMenu.Item>
 );
 

--- a/src/core/components/Menu.tsx
+++ b/src/core/components/Menu.tsx
@@ -4,6 +4,7 @@ import clsx from "clsx";
 import { Classes as ButtonClasses } from "./Button/Button";
 import { Fragment, ReactNode } from "react";
 import { ReactElement } from "react-markdown/lib/react-markdown";
+import Link from "next/link";
 
 export const MenuClasses = {
   Menu: "relative",
@@ -63,13 +64,13 @@ const Item = ({
   activeClassName = MenuClasses.ActiveItem,
   onClick,
   className = MenuClasses.Item,
-  linkTo,
+  href,
 }: {
   children: ReactNode;
   onClick?: ((event: { preventDefault: Function }) => void) | undefined;
   className?: string;
   activeClassName?: string;
-  linkTo?: string;
+  href?: string;
 }) => (
   <HeadlessMenu.Item>
     {({ active }) =>
@@ -81,9 +82,12 @@ const Item = ({
           {children}
         </button>
       ) : (
-        <a href={linkTo} className={clsx(className, active && activeClassName)}>
+        <Link
+          href={href || ""}
+          className={clsx(className, active && activeClassName)}
+        >
           {children}
-        </a>
+        </Link>
       )
     }
   </HeadlessMenu.Item>

--- a/src/core/components/Menu.tsx
+++ b/src/core/components/Menu.tsx
@@ -14,7 +14,7 @@ export const MenuClasses = {
     ButtonClasses.white,
     ButtonClasses.md
   ),
-  Item: "group flex px-2 py-2 items-center w-full text-sm rounded hover:bg-blue-500 hover:text-white",
+  Item: "group flex transition px-2 py-2 items-center w-full text-sm rounded hover:bg-blue-500 hover:text-white",
   ActiveItem: "bg-blue-500 text-white",
   Items:
     "origin-top-right absolute right-0 mt-2 w-36 ring-1 ring-black ring-opacity-5 rounded shadow-lg bg-white text-gray-900 focus:outline-none text-right z-40 divide-y divide-gray-200 ",
@@ -65,7 +65,7 @@ type ItemProps = {
   activeClassName?: string;
 } & (
   | {
-      onClick: ((event: { preventDefault: Function }) => void) | undefined;
+      onClick: (event: { preventDefault: Function }) => void;
       href?: never;
     }
   | { onClick?: never; href: string }

--- a/src/core/components/Menu.tsx
+++ b/src/core/components/Menu.tsx
@@ -64,7 +64,7 @@ const Item = ({
   activeClassName = MenuClasses.ActiveItem,
   onClick,
   className = MenuClasses.Item,
-  href,
+  href = "",
 }: {
   children: ReactNode;
   onClick?: ((event: { preventDefault: Function }) => void) | undefined;
@@ -83,7 +83,7 @@ const Item = ({
         </button>
       ) : (
         <Link
-          href={href || ""}
+          href={href}
           className={clsx(className, active && activeClassName)}
         >
           {children}


### PR DESCRIPTION
Fix https://github.com/BLSQ/openhexa-team/issues/92 

## Changes

Please list / describe the changes in the codebase for the reviewer(s).

- add linkTo props to MenuItem component

## How/what to test

Click on the user menu dropdown and check if the items can be opened in a new tab.

## Screenshots / screencast
![image](https://user-images.githubusercontent.com/25453621/201918184-8471147d-b239-4fb2-b2b8-3d4eabe1c469.png)

