### PR TITLE
fix(Pipelines): Display an error when user types an invalid json configuration

### DIFF
--- a/src/pipelines/features/PipelineRunForm/GenericForm.tsx
+++ b/src/pipelines/features/PipelineRunForm/GenericForm.tsx
@@ -24,7 +24,9 @@ const GenericForm = (props: GenericFormProps) => {
       try {
         JSON.parse(values.textConfig ?? "");
       } catch {
-        errors.config = t("Invalid configuration. This is not a valid JSON.");
+        errors.textConfig = t(
+          "Invalid configuration. This is not a valid JSON."
+        );
       }
 
       return errors;
@@ -45,6 +47,7 @@ const GenericForm = (props: GenericFormProps) => {
         name="config"
         label={t("Configuration")}
         required
+        error={form.errors.textConfig}
         readOnly={readOnly}
         className="col-span-2"
       >


### PR DESCRIPTION
## Changes

Display the error below the configuration field

## How/what to test

Type an invalid json in the configuration of a pipeline

