### PR TITLE
fix(Workspaces):display warning when user can't create workspace

### DIFF
--- a/public/locales/en/messages.json
+++ b/public/locales/en/messages.json
@@ -150,6 +150,7 @@
   "No elements to display": "No elements to display",
   "No logs": "No logs",
   "No results to display.": "No results to display.",
+  "No workspace available at the moment": "",
   "Notebooks": "Notebooks",
   "Open in Airflow": "Open in Airflow",
   "OpenHexa Metadata": "OpenHexa Metadata",

--- a/public/locales/fr/messages.json
+++ b/public/locales/fr/messages.json
@@ -150,6 +150,7 @@
   "No elements to display": "",
   "No logs": "",
   "No results to display.": "",
+  "No workspace available at the moment": "",
   "Notebooks": "",
   "Open in Airflow": "",
   "OpenHexa Metadata": "",

--- a/src/pages/workspaces/index.tsx
+++ b/src/pages/workspaces/index.tsx
@@ -1,5 +1,8 @@
+import Alert from "core/components/Alert";
 import Page from "core/components/Page";
 import { createGetServerSideProps } from "core/helpers/page";
+import useMe from "identity/hooks/useMe";
+import { useRouter } from "next/router";
 import { ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 import CreateWorkspaceDialog from "workspaces/features/CreateWorkspaceDialog";
@@ -10,8 +13,17 @@ import {
 
 const WorkspacesHome = () => {
   const { t } = useTranslation();
-
+  const me = useMe();
+  const router = useRouter();
   const handleClose = () => {};
+
+  if (!me.permissions.createWorkspace) {
+    return (
+      <Alert onClose={() => router.push("/")} icon="warning">
+        {t("No workspace available at the moment")}
+      </Alert>
+    );
+  }
 
   return (
     <Page title={t("New workspace")}>
@@ -31,10 +43,7 @@ export const getServerSideProps = createGetServerSideProps({
     });
 
     if (!data.workspaces || !data.workspaces.items.length) {
-      if (
-        ctx.me?.features.filter((f) => f.code === "workspaces")[0] &&
-        ctx.me.permissions.createWorkspace
-      ) {
+      if (ctx.me?.features.filter((f) => f.code === "workspaces")[0]) {
         return {
           props: {},
         };


### PR DESCRIPTION
Fix for https://github.com/orgs/BLSQ/projects/4/views/2?filterQuery=label%3Abug&pane=issue&itemId=18245334

## Changes

Please list / describe the changes in the codebase for the reviewer(s).

- Check if user can create workspace on client-side if he didn't have one.
- Change 2

## How/what to test

A few words about what needs to be tested, along with specific testing instructions if needed.

## Screenshots / screencast

If relevant, please add some screenshots or a short video.