### PR TITLE
fix(Pipelines): Move fields from Airflow data & collapse it by default

### DIFF
--- a/src/core/components/DataCard/FormSection.tsx
+++ b/src/core/components/DataCard/FormSection.tsx
@@ -1,10 +1,10 @@
-import { Disclosure } from "@headlessui/react";
 import {
   ChevronDownIcon,
   ChevronRightIcon,
   PencilIcon,
 } from "@heroicons/react/24/outline";
 
+import { BlockSection } from "core/components/Block";
 import useForm, { FormInstance } from "core/hooks/useForm";
 import {
   getValue,
@@ -23,10 +23,9 @@ import {
 } from "react";
 import Button from "../Button/Button";
 import DescriptionList, { DescriptionListProps } from "../DescriptionList";
-import Spinner from "../Spinner";
 import DisableClickPropagation from "../DisableClickPropagation";
+import Spinner from "../Spinner";
 import { DataCardSectionContext } from "./context";
-import { BlockSection } from "core/components/Block";
 import { Property, PropertyDefinition, PropertyFlag } from "./types";
 
 export type OnSaveFn = (
@@ -82,6 +81,8 @@ function FormSection<F extends { [key: string]: any }>(
     className,
     displayMode,
     columns,
+    collapsible,
+    defaultOpen,
     children,
     onSave,
   } = props;
@@ -157,6 +158,8 @@ function FormSection<F extends { [key: string]: any }>(
   return (
     <DataCardSectionContext.Provider value={section}>
       <BlockSection
+        collapsible={collapsible}
+        defaultOpen={defaultOpen}
         className={className}
         title={({ open }) => (
           <>

--- a/src/pages/pipelines/[pipelineId]/index.tsx
+++ b/src/pages/pipelines/[pipelineId]/index.tsx
@@ -150,19 +150,6 @@ const PipelinePage = (props: Props) => {
                 defaultValue="-"
               />
               <TextProperty
-                id="description"
-                accessor={"description"}
-                label={t("Description")}
-                defaultValue="-"
-                markdown
-              />
-            </DataCard.FormSection>
-            <DataCard.FormSection
-              title={t("Airflow Data")}
-              onSave={onSave}
-              defaultOpen={false}
-            >
-              <TextProperty
                 readonly
                 id="externalId"
                 accessor="externalId"
@@ -175,6 +162,19 @@ const PipelinePage = (props: Props) => {
                 label={t("Schedule")}
                 defaultValue="-"
               />
+              <TextProperty
+                id="description"
+                accessor={"description"}
+                label={t("Description")}
+                defaultValue="-"
+                markdown
+              />
+            </DataCard.FormSection>
+            <DataCard.FormSection
+              title={t("Airflow Data")}
+              onSave={onSave}
+              defaultOpen={false}
+            >
               <UserProperty id="user" accessor="user" label={t("Report to")} />
               <TextProperty
                 readonly


### PR DESCRIPTION
Move `id` & `schedule` In the first block.
Collapse  "Airflow Data" by default
<img width="941" alt="CleanShot 2023-02-08 at 15 46 27@2x" src="https://user-images.githubusercontent.com/1607549/217563955-dc7e510e-8744-4f81-bc7a-1aa57cb538aa.png">
