### PR TITLE
Fix workspace connection

### DIFF
--- a/src/core/components/DataCard/FormSection.tsx
+++ b/src/core/components/DataCard/FormSection.tsx
@@ -1,10 +1,10 @@
-import { Disclosure } from "@headlessui/react";
 import {
   ChevronDownIcon,
   ChevronRightIcon,
   PencilIcon,
 } from "@heroicons/react/24/outline";
 
+import { BlockSection } from "core/components/Block";
 import useForm, { FormInstance } from "core/hooks/useForm";
 import {
   getValue,
@@ -23,10 +23,9 @@ import {
 } from "react";
 import Button from "../Button/Button";
 import DescriptionList, { DescriptionListProps } from "../DescriptionList";
-import Spinner from "../Spinner";
 import DisableClickPropagation from "../DisableClickPropagation";
+import Spinner from "../Spinner";
 import { DataCardSectionContext } from "./context";
-import { BlockSection } from "core/components/Block";
 import { Property, PropertyDefinition, PropertyFlag } from "./types";
 
 export type OnSaveFn = (
@@ -82,6 +81,8 @@ function FormSection<F extends { [key: string]: any }>(
     className,
     displayMode,
     columns,
+    collapsible,
+    defaultOpen,
     children,
     onSave,
   } = props;
@@ -157,6 +158,8 @@ function FormSection<F extends { [key: string]: any }>(
   return (
     <DataCardSectionContext.Provider value={section}>
       <BlockSection
+        collapsible={collapsible}
+        defaultOpen={defaultOpen}
         className={className}
         title={({ open }) => (
           <>

--- a/src/core/helpers/apollo.ts
+++ b/src/core/helpers/apollo.ts
@@ -58,6 +58,7 @@ const CACHE_CONFIG: InMemoryCacheConfig = {
     },
     Workspace: {
       merge: true,
+      keyFields: ["slug"],
     },
   },
 };

--- a/src/pages/pipelines/[pipelineId]/index.tsx
+++ b/src/pages/pipelines/[pipelineId]/index.tsx
@@ -150,19 +150,6 @@ const PipelinePage = (props: Props) => {
                 defaultValue="-"
               />
               <TextProperty
-                id="description"
-                accessor={"description"}
-                label={t("Description")}
-                defaultValue="-"
-                markdown
-              />
-            </DataCard.FormSection>
-            <DataCard.FormSection
-              title={t("Airflow Data")}
-              onSave={onSave}
-              defaultOpen={false}
-            >
-              <TextProperty
                 readonly
                 id="externalId"
                 accessor="externalId"
@@ -175,6 +162,19 @@ const PipelinePage = (props: Props) => {
                 label={t("Schedule")}
                 defaultValue="-"
               />
+              <TextProperty
+                id="description"
+                accessor={"description"}
+                label={t("Description")}
+                defaultValue="-"
+                markdown
+              />
+            </DataCard.FormSection>
+            <DataCard.FormSection
+              title={t("Airflow Data")}
+              onSave={onSave}
+              defaultOpen={false}
+            >
               <UserProperty id="user" accessor="user" label={t("Report to")} />
               <TextProperty
                 readonly

--- a/src/workspaces/helpers/connection.tsx
+++ b/src/workspaces/helpers/connection.tsx
@@ -41,7 +41,8 @@ export function getUsageSnippets(
     fields: { code: string }[];
   }
 ) {
-  const slugify = (...keys: string[]) => keys.join("_").toUpperCase();
+  const slugify = (...keys: string[]) =>
+    keys.join("_").replace("-", "_").toUpperCase();
 
   switch (connection.type) {
     case ConnectionType.Dhis2:
@@ -136,13 +137,15 @@ with io.StringIO() as csv_buffer:
 import os
 
 # Get connection fields from environment variables
-${connection.fields.map(
-  (f) => `${slugify(connection.slug, f.code)} = os.getenv("${slugify(
-    connection.slug,
-    f.code
-  )}")
+${connection.fields
+  .map(
+    (f) => `${slugify(connection.slug, f.code)} = os.getenv("${slugify(
+      connection.slug,
+      f.code
+    )}")
 `
-)}
+  )
+  .join("")}
 `,
         },
       ];


### PR DESCRIPTION
Since we do not use the workspace id on the frontend anymore, we have to set the identifier field in Apollo to be able to store the data in the cache

Python snippet for custom connection was incorrect