### PR TITLE
fix(Workspaces): updated workspace description not refreshed

### DIFF
--- a/src/pages/workspaces/[workspaceSlug]/index.tsx
+++ b/src/pages/workspaces/[workspaceSlug]/index.tsx
@@ -60,13 +60,15 @@ const WorkspaceHome: NextPageWithLayout = (props: Props) => {
           </Block.Content>
         </Block>
       </WorkspaceLayout.PageContent>
-      <UpdateDescriptionDialog
-        open={isDialogOpen}
-        workspace={workspace}
-        onClose={() => {
-          setIsDialogOpen(false);
-        }}
-      />
+      {isDialogOpen && (
+        <UpdateDescriptionDialog
+          open={isDialogOpen}
+          workspace={workspace}
+          onClose={() => {
+            setIsDialogOpen(false);
+          }}
+        />
+      )}
     </Page>
   );
 };

--- a/src/workspaces/features/UpdateDescriptionDialog/UpdateDescriptionDialog.tsx
+++ b/src/workspaces/features/UpdateDescriptionDialog/UpdateDescriptionDialog.tsx
@@ -9,6 +9,7 @@ import { useUpdateWorkspaceMutation } from "workspaces/graphql/mutations.generat
 import { gql } from "@apollo/client";
 import { UpdateWorkspaceError } from "graphql-types";
 import { UpdateWorkspaceDescription_WorkspaceFragment } from "./UpdateDescriptionDialog.generated";
+import useCacheKey from "core/hooks/useCacheKey";
 
 type UpdateDescriptionDialogProps = {
   onClose(): void;
@@ -24,6 +25,7 @@ const UpdateDescriptionDialog = (props: UpdateDescriptionDialogProps) => {
   const { t } = useTranslation();
   const { open, onClose, workspace } = props;
   const [mutate] = useUpdateWorkspaceMutation();
+  const clearCache = useCacheKey(["workspace", workspace.slug]);
 
   const form = useForm<Form>({
     onSubmit: async (values) => {
@@ -45,6 +47,7 @@ const UpdateDescriptionDialog = (props: UpdateDescriptionDialogProps) => {
       ) {
         throw new Error("You are not authorized to perform this action");
       }
+      clearCache();
       onClose();
     },
     validate: (values) => {


### PR DESCRIPTION
Fix for  workspace description not refreshed when updated.
 
## Changes

Please list / describe the changes in the codebase for the reviewer(s).

- Use the cacheKey mechanism to update the home page component when the edit mutation is successfully done.

## Screenshots / screencast

[Screencast from 15.02.2023 13:31:07.webm](https://user-images.githubusercontent.com/25453621/219042049-8e47847c-b937-4b75-96d7-b27269f70940.webm)
