### PR TITLE
fix(Workspaces) : allow only workspace admins to access settings page

### DIFF
--- a/src/pages/workspaces/[workspaceSlug]/settings.tsx
+++ b/src/pages/workspaces/[workspaceSlug]/settings.tsx
@@ -180,18 +180,9 @@ export const getServerSideProps = createGetServerSideProps({
       },
     });
 
-    if (!data.workspace) {
+    if (!data.workspace || !data.workspace.permissions.manageMembers) {
       return {
         notFound: true,
-      };
-    }
-    const { permissions } = data.workspace;
-    if (!permissions.manageMembers) {
-      return {
-        redirect: {
-          permanent: false,
-          destination: `/workspaces`,
-        },
       };
     }
 

--- a/src/pages/workspaces/[workspaceSlug]/settings.tsx
+++ b/src/pages/workspaces/[workspaceSlug]/settings.tsx
@@ -185,6 +185,15 @@ export const getServerSideProps = createGetServerSideProps({
         notFound: true,
       };
     }
+    const { permissions } = data.workspace;
+    if (!permissions.manageMembers) {
+      return {
+        redirect: {
+          permanent: false,
+          destination: `/workspaces`,
+        },
+      };
+    }
 
     return {
       props: {


### PR DESCRIPTION
User that belongs to a workspace and didn't have the  admin role for the workspace can access to the settings page by typing /workspaces/[slug]/settings.

## Changes

- Redirect to home page if  current user  doesn't have permission to manage a workspace.


## How/what to test
Create/Use a no workspace admin and try to access to /workspaces/[slug]/settings (should be redirected to /workspaces)