### PR TITLE
feat(Workspaces): hide notebooks menu entry for user with role VIEWER

### DIFF
--- a/src/pages/workspaces/[workspaceSlug]/notebooks.tsx
+++ b/src/pages/workspaces/[workspaceSlug]/notebooks.tsx
@@ -66,7 +66,7 @@ export const getServerSideProps = createGetServerSideProps({
     });
     await WorkspaceLayout.prefetch(client);
 
-    if (!data.workspace || !data.workspace.permissions.manageMembers) {
+    if (!data.workspace || !data.workspace.permissions.update) {
       return {
         notFound: true,
       };

--- a/src/pages/workspaces/[workspaceSlug]/notebooks.tsx
+++ b/src/pages/workspaces/[workspaceSlug]/notebooks.tsx
@@ -66,7 +66,7 @@ export const getServerSideProps = createGetServerSideProps({
     });
     await WorkspaceLayout.prefetch(client);
 
-    if (!data.workspace) {
+    if (!data.workspace || !data.workspace.permissions.manageMembers) {
       return {
         notFound: true,
       };

--- a/src/workspaces/__tests__/__snapshots__/workspaces.test.tsx.snap
+++ b/src/workspaces/__tests__/__snapshots__/workspaces.test.tsx.snap
@@ -237,3 +237,268 @@ exports[`Workspaces renders the workspace page 1`] = `
   </main>
 </div>
 `;
+
+exports[`Workspaces shows the jupyterhub entry when user have the update permission  1`] = `
+<div>
+  <div
+    class="fixed inset-y-0 flex w-64 flex-col"
+  >
+    <div
+      class="flex flex-grow flex-col overflow-y-auto border-r border-gray-200 bg-gray-800"
+    >
+      <div
+        class="w-full"
+      >
+        <button
+          class="group flex h-16 w-full items-center bg-gray-800 px-2 text-left hover:bg-gray-600"
+        >
+          <div
+            class="flex-1 text-sm tracking-tight text-gray-50 line-clamp-2"
+            title="Rwanda Workspace"
+          >
+            Rwanda Workspace
+            <div
+              class="text-xs tracking-tighter text-gray-500 group-hover:text-gray-400"
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="ml-1 h-4 w-4 text-gray-500 group-hover:text-gray-100"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M12.53 16.28a.75.75 0 01-1.06 0l-7.5-7.5a.75.75 0 011.06-1.06L12 14.69l6.97-6.97a.75.75 0 111.06 1.06l-7.5 7.5z"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        class="mt-5 flex flex-grow flex-col"
+      >
+        <nav
+          class="flex-1 space-y-1 px-0 pb-4"
+        >
+          <a
+            class="text-md group flex items-center gap-3 border-l-4 px-2 py-2 font-medium border-transparent text-gray-300 hover:bg-gray-700 hover:text-white"
+            href="/workspaces/a303ff37-644b-4080-83d9-a42bd2712f63"
+          >
+            <svg
+              aria-hidden="true"
+              class="h-5 w-5"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            Home
+          </a>
+          <a
+            class="text-md group flex items-center gap-3 border-l-4 px-2 py-2 font-medium border-transparent text-gray-300 hover:bg-gray-700 hover:text-white"
+            href="/workspaces/a303ff37-644b-4080-83d9-a42bd2712f63/files"
+          >
+            <svg
+              aria-hidden="true"
+              class="h-5 w-5"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M3.75 9.776c.112-.017.227-.026.344-.026h15.812c.117 0 .232.009.344.026m-16.5 0a2.25 2.25 0 00-1.883 2.542l.857 6a2.25 2.25 0 002.227 1.932H19.05a2.25 2.25 0 002.227-1.932l.857-6a2.25 2.25 0 00-1.883-2.542m-16.5 0V6A2.25 2.25 0 016 3.75h3.879a1.5 1.5 0 011.06.44l2.122 2.12a1.5 1.5 0 001.06.44H18A2.25 2.25 0 0120.25 9v.776"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            Files
+          </a>
+          <a
+            class="text-md group flex items-center gap-3 border-l-4 px-2 py-2 font-medium border-transparent text-gray-300 hover:bg-gray-700 hover:text-white"
+            href="/workspaces/a303ff37-644b-4080-83d9-a42bd2712f63/databases"
+          >
+            <svg
+              aria-hidden="true"
+              class="h-5 w-5"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            Database
+          </a>
+          <a
+            class="text-md group flex items-center gap-3 border-l-4 px-2 py-2 font-medium border-transparent text-gray-300 hover:bg-gray-700 hover:text-white"
+            href="/workspaces/a303ff37-644b-4080-83d9-a42bd2712f63/connections"
+          >
+            <svg
+              aria-hidden="true"
+              class="h-5 w-5"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M4.098 19.902a3.75 3.75 0 005.304 0l6.401-6.402M6.75 21A3.75 3.75 0 013 17.25V4.125C3 3.504 3.504 3 4.125 3h5.25c.621 0 1.125.504 1.125 1.125v4.072M6.75 21a3.75 3.75 0 003.75-3.75V8.197M6.75 21h13.125c.621 0 1.125-.504 1.125-1.125v-5.25c0-.621-.504-1.125-1.125-1.125h-4.072M10.5 8.197l2.88-2.88c.438-.439 1.15-.439 1.59 0l3.712 3.713c.44.44.44 1.152 0 1.59l-2.879 2.88M6.75 17.25h.008v.008H6.75v-.008z"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            Connections
+          </a>
+          <a
+            class="text-md group flex items-center gap-3 border-l-4 px-2 py-2 font-medium border-transparent text-gray-300 hover:bg-gray-700 hover:text-white"
+            href="/workspaces/a303ff37-644b-4080-83d9-a42bd2712f63/pipelines"
+          >
+            <svg
+              aria-hidden="true"
+              class="h-5 w-5"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            Pipelines
+          </a>
+          <a
+            class="text-md group flex items-center gap-3 border-l-4 px-2 py-2 font-medium border-transparent text-gray-300 hover:bg-gray-700 hover:text-white"
+            href="/workspaces/a303ff37-644b-4080-83d9-a42bd2712f63/notebooks"
+          >
+            <svg
+              aria-hidden="true"
+              class="h-5 w-5"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            JupyterHub
+          </a>
+        </nav>
+      </div>
+      <div
+        class="mb-5 flex flex-shrink-0 flex-col items-center px-4"
+      >
+        <a
+          class="relative flex h-8 flex-shrink-0 items-center"
+          href="/"
+        >
+          <img
+            alt="OpenHexa logo"
+            class="h-full"
+            src="/images/logo_with_text_white.svg"
+          />
+        </a>
+      </div>
+    </div>
+  </div>
+  <main
+    class="flex flex-col pl-64"
+  >
+    <div
+      class="sticky top-0 z-10 flex h-16 flex-shrink-0 items-center justify-between border-b border-gray-200 bg-white py-3 shadow px-4 md:px-6 xl:px-10 2xl:px-12"
+    >
+      <div
+        class="flex-1 flex items-center justify-between"
+      >
+        <nav
+          aria-label="Breadcrumbs"
+        >
+          <ol
+            class="flex items-center"
+            role="list"
+          >
+            <li
+              class=""
+            >
+              <div
+                class="flex items-center"
+              >
+                <span
+                  class="text-sm hover:text-gray-700 font-medium text-gray-500"
+                >
+                  <a
+                    class=""
+                    href="/workspaces/a303ff37-644b-4080-83d9-a42bd2712f63"
+                  >
+                    Rwanda Workspace
+                  </a>
+                </span>
+              </div>
+            </li>
+          </ol>
+        </nav>
+        <button
+          class="relative rounded h-fit
+    focus:outline-none focus:ring-2 focus:ring-offset-2
+    inline-flex items-center justify-center transition-all
+    border font-medium
+    disabled:opacity-50 disabled:cursor-not-allowed
+   text-sm px-3 py-2.5 leading-4 shadow-sm border-transparent text-white bg-blue-600 hover:bg-blue-700 focus:ring-blue-500"
+        >
+          Edit
+        </button>
+      </div>
+    </div>
+    <div
+      class="py-6 xl:py-8"
+    >
+      <div
+        class="mx-auto px-4 md:px-6 xl:px-10  2xl:px-12"
+      >
+        <article
+          class="sm:rounded-lg overflow-hidden shadow border-b border-gray-200 bg-white"
+        >
+          <section
+            class="px-4 py-5 sm:px-6"
+          >
+            <div>
+              <div
+                class="prose prose-headings:font-medium max-w-3xl"
+              >
+                <p>
+                  This is a description
+                </p>
+              </div>
+            </div>
+          </section>
+        </article>
+      </div>
+    </div>
+  </main>
+</div>
+`;

--- a/src/workspaces/__tests__/__snapshots__/workspaces.test.tsx.snap
+++ b/src/workspaces/__tests__/__snapshots__/workspaces.test.tsx.snap
@@ -153,27 +153,6 @@ exports[`Workspaces renders the workspace page 1`] = `
             </svg>
             Pipelines
           </a>
-          <a
-            class="text-md group flex items-center gap-3 border-l-4 px-2 py-2 font-medium border-transparent text-gray-300 hover:bg-gray-700 hover:text-white"
-            href="/workspaces/test/notebooks"
-          >
-            <svg
-              aria-hidden="true"
-              class="h-5 w-5"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-            JupyterHub
-          </a>
         </nav>
       </div>
       <div

--- a/src/workspaces/__tests__/workspaces.test.tsx
+++ b/src/workspaces/__tests__/workspaces.test.tsx
@@ -115,4 +115,46 @@ describe("Workspaces", () => {
     expect(editButton).toBeNull();
     expect(container).toMatchSnapshot();
   });
+
+  it("shows the jupyterhub entry when user have the update permission ", async () => {
+    const slug = "a303ff37-644b-4080-83d9-a42bd2712f63";
+    const graphqlMocks = [
+      {
+        request: {
+          query: WorkspacePageDocument,
+          variables: {
+            slug,
+          },
+        },
+        result: {
+          data: {
+            workspace: {
+              slug,
+              name: "Rwanda Workspace",
+              description: "This is a description",
+              permissions: {
+                update: true,
+                delete: false,
+                manageMembers: false,
+              },
+              countries: [],
+              members: {
+                totalItems: 0,
+                items: [],
+              },
+            },
+          },
+        },
+      },
+    ];
+
+    const { container } = render(
+      <TestApp mocks={graphqlMocks}>
+        <WorkspacePage page={1} perPage={1} workspaceSlug={slug} />
+      </TestApp>
+    );
+    const elm = await screen.findByText("JupyterHub", { selector: "a" });
+    expect(elm).toBeInTheDocument();
+    expect(container).toMatchSnapshot();
+  });
 });

--- a/src/workspaces/graphql/queries.generated.tsx
+++ b/src/workspaces/graphql/queries.generated.tsx
@@ -40,7 +40,7 @@ export type WorkspaceNotebooksPageQueryVariables = Types.Exact<{
 }>;
 
 
-export type WorkspaceNotebooksPageQuery = { __typename?: 'Query', notebooksUrl: any, workspace?: { __typename?: 'Workspace', slug: string, name: string, permissions: { __typename?: 'WorkspacePermissions', manageMembers: boolean }, countries: Array<{ __typename?: 'Country', flag: string, code: string }> } | null };
+export type WorkspaceNotebooksPageQuery = { __typename?: 'Query', notebooksUrl: any, workspace?: { __typename?: 'Workspace', slug: string, name: string, permissions: { __typename?: 'WorkspacePermissions', update: boolean, manageMembers: boolean }, countries: Array<{ __typename?: 'Country', flag: string, code: string }> } | null };
 
 export type WorkspacePipelinePageQueryVariables = Types.Exact<{
   workspaceSlug: Types.Scalars['String'];
@@ -247,6 +247,9 @@ export const WorkspaceNotebooksPageDocument = gql`
   notebooksUrl
   workspace(slug: $workspaceSlug) {
     slug
+    permissions {
+      update
+    }
     ...WorkspaceLayout_workspace
   }
 }

--- a/src/workspaces/graphql/queries.graphql
+++ b/src/workspaces/graphql/queries.graphql
@@ -45,6 +45,9 @@ query WorkspaceNotebooksPage($workspaceSlug: String!) {
   notebooksUrl
   workspace(slug: $workspaceSlug) {
     slug
+    permissions{
+      update
+    }
     ...WorkspaceLayout_workspace
   }
 }

--- a/src/workspaces/layouts/WorkspaceLayout/Sidebar.tsx
+++ b/src/workspaces/layouts/WorkspaceLayout/Sidebar.tsx
@@ -103,10 +103,14 @@ const Sidebar = (props: SidebarProps) => {
               <ArrowPathIcon className="h-5 w-5" />
               {t("Pipelines")}
             </NavItem>
-            <NavItem href={`/workspaces/${encodeURIComponent(slug)}/notebooks`}>
-              <BookOpenIcon className="h-5 w-5" />
-              {t("JupyterHub")}
-            </NavItem>
+            {workspace.permissions.update && (
+              <NavItem
+                href={`/workspaces/${encodeURIComponent(slug)}/notebooks`}
+              >
+                <BookOpenIcon className="h-5 w-5" />
+                {t("JupyterHub")}
+              </NavItem>
+            )}
             {workspace.permissions.manageMembers && (
               <NavItem
                 href={`/workspaces/${encodeURIComponent(slug)}/settings`}


### PR DESCRIPTION
Hide JupyterHub menu entry on the sidebar for user with role VIEWER.

## Changes

Please list / describe the changes in the codebase for the reviewer(s).

- Hide menu entry
- Return not found when user try to access to /notebooks

## How/what to test

Create a Workspace Member with Role Viewer, connect with it and check that the JupyterHub menu entry is hidden and  try to access to /notebooks.
