### PR TITLE
fix(Workspaces): hide administration link for non admin/staff user

### DIFF
--- a/src/workspaces/features/SidebarMenu/SidebarMenu.tsx
+++ b/src/workspaces/features/SidebarMenu/SidebarMenu.tsx
@@ -233,7 +233,7 @@ const SidebarMenu = (props: SidebarMenuProps) => {
               <UserIcon className="h-5 w-5 text-gray-400 transition-all group-hover:text-gray-600" />
               {t("Account settings")}
             </Link>
-            {isAdmin && (
+            {me.permissions.adminPanel && (
               <Link
                 href="/admin"
                 noStyle


### PR DESCRIPTION
Hide link to  Administration page for non admin/staff user.

## Changes

Please list / describe the changes in the codebase for the reviewer(s).

- check on user permissions instead of features.