### PR TITLE
fix(Workspaces): allow access to only users with workspaces feature

### DIFF
--- a/src/core/helpers/page.ts
+++ b/src/core/helpers/page.ts
@@ -75,6 +75,18 @@ export function createGetServerSideProps(options: CreateGetServerSideProps) {
           },
         };
       }
+
+      if (
+        !features.some((f) => f.code === "workspaces") &&
+        ctx.resolvedUrl.startsWith("/workspaces")
+      ) {
+        return {
+          redirect: {
+            permanent: false,
+            destination: "/",
+          },
+        };
+      }
     }
     result.props = {
       ...result.props,


### PR DESCRIPTION
Fix for [issue](https://github.com/BLSQ/openhexa-team/issues/381) .

## Changes

Please list / describe the changes in the codebase for the reviewer(s).

- Check if user has workspaces feature before redirection.

## How/what to test

Create a user with only openhexa_legacy  feature  and try to access to a workspace, you should be redirected to home page.
