### PR TITLE
feat(Workspaces): hide connections/database parameters  for viewers

### DIFF
--- a/src/pages/workspaces/[workspaceSlug]/connections/[connectionId].tsx
+++ b/src/pages/workspaces/[workspaceSlug]/connections/[connectionId].tsx
@@ -142,7 +142,9 @@ const WorkspaceConnectionPage: NextPageWithLayout = ({
                   accessor="description"
                 />
               </DataCard.FormSection>
-              <ConnectionFieldsSection connection={connection} />
+              {workspace.permissions.update && (
+                <ConnectionFieldsSection connection={connection} />
+              )}
             </div>
             <DataCard.Section title={t("Usage")}>
               <p className="text-sm text-gray-900">

--- a/src/pages/workspaces/[workspaceSlug]/databases/index.tsx
+++ b/src/pages/workspaces/[workspaceSlug]/databases/index.tsx
@@ -124,9 +124,11 @@ const WorkspaceDatabasesPage: NextPageWithLayout = (props: Props) => {
             />
           </DataGrid>
           <Block className="divide-y-2">
-            <Block.Section collapsible title={t("Connection parameters")}>
-              <DatabaseVariablesSection workspace={workspace} />
-            </Block.Section>
+            {workspace.permissions.update && (
+              <Block.Section collapsible title={t("Connection parameters")}>
+                <DatabaseVariablesSection workspace={workspace} />
+              </Block.Section>
+            )}
             <Block.Section collapsible={false} title={t("Usage")}>
               <p className="text-sm text-gray-900">
                 {t("Documentation for database usage is available at ")}

--- a/src/workspaces/features/DatabaseVariablesSection/DatabaseVariablesSection.tsx
+++ b/src/workspaces/features/DatabaseVariablesSection/DatabaseVariablesSection.tsx
@@ -68,7 +68,7 @@ const DatabaseVariablesSection = (props: DatabaseVariablesSectionProps) => {
       </BaseColumn>
       <BaseColumn className="flex gap-x-2 text-gray-900" label={t("Value")}>
         {(field) => (
-          <div className="flex  gap-x-1 truncate">
+          <div className="flex gap-x-1 truncate">
             {field.secret && field.value && <SecretField value={field.value} />}
             {!field.secret && (
               <>

--- a/src/workspaces/features/DatabaseVariablesSection/SecretField.tsx
+++ b/src/workspaces/features/DatabaseVariablesSection/SecretField.tsx
@@ -1,5 +1,9 @@
 import ClipboardButton from "core/components/ClipboardButton";
-import { EyeIcon, EyeSlashIcon } from "@heroicons/react/24/outline";
+import {
+  EyeIcon,
+  EyeSlashIcon,
+  LockClosedIcon,
+} from "@heroicons/react/24/outline";
 import { useCallback, useState } from "react";
 
 const SecretField = (field: { value: string | number }) => {
@@ -27,6 +31,7 @@ const SecretField = (field: { value: string | number }) => {
   }
   return (
     <div className="flex items-start gap-x-2">
+      <LockClosedIcon className="h-3 w-3" />
       <span>*********</span>
       <button
         onClick={toggleSecret}

--- a/src/workspaces/graphql/queries.generated.tsx
+++ b/src/workspaces/graphql/queries.generated.tsx
@@ -118,7 +118,7 @@ export type ConnectionPageQueryVariables = Types.Exact<{
 }>;
 
 
-export type ConnectionPageQuery = { __typename?: 'Query', workspace?: { __typename?: 'Workspace', slug: string, name: string, permissions: { __typename?: 'WorkspacePermissions', manageMembers: boolean, update: boolean }, countries: Array<{ __typename?: 'Country', flag: string, code: string }> } | null, connection?: { __typename?: 'Connection', id: string, name: string, slug: string, description?: string | null, type: Types.ConnectionType, createdAt: any, permissions: { __typename?: 'ConnectionPermissions', update: boolean, delete: boolean }, fields: Array<{ __typename?: 'ConnectionField', code: string, value?: string | null, secret: boolean }> } | null };
+export type ConnectionPageQuery = { __typename?: 'Query', workspace?: { __typename?: 'Workspace', slug: string, name: string, permissions: { __typename?: 'WorkspacePermissions', update: boolean, manageMembers: boolean }, countries: Array<{ __typename?: 'Country', flag: string, code: string }> } | null, connection?: { __typename?: 'Connection', id: string, name: string, slug: string, description?: string | null, type: Types.ConnectionType, createdAt: any, permissions: { __typename?: 'ConnectionPermissions', update: boolean, delete: boolean }, fields: Array<{ __typename?: 'ConnectionField', code: string, value?: string | null, secret: boolean }> } | null };
 
 export type CheckWorkspaceAvailabilityQueryVariables = Types.Exact<{
   slug: Types.Scalars['String'];
@@ -728,6 +728,9 @@ export const ConnectionPageDocument = gql`
   workspace(slug: $workspaceSlug) {
     slug
     name
+    permissions {
+      update
+    }
     ...WorkspaceLayout_workspace
   }
   connection(id: $connectionId) {

--- a/src/workspaces/graphql/queries.graphql
+++ b/src/workspaces/graphql/queries.graphql
@@ -264,6 +264,9 @@ query ConnectionPage($workspaceSlug: String!, $connectionId: UUID!) {
   workspace(slug: $workspaceSlug) {
     slug
     name
+    permissions{
+      update
+    }
     ...WorkspaceLayout_workspace
   }
   connection(id: $connectionId) {


### PR DESCRIPTION
Hide connections/database parameters  sections for viewer.



## Changes

Please list / describe the changes in the codebase for the reviewer(s).

- Check if user is editor or admin (editor and admin have update permission on workspace)/

## How/what to test
Log into a workspace as a viewer, go to the database page and check that locked icons are displayed for each parameter.

## Screenshots / screencast
Database
![image](https://github.com/BLSQ/openhexa-frontend/assets/25453621/2ea38836-f5cf-4924-9cae-a6f3cf96c22d)

Connection
![image](https://github.com/BLSQ/openhexa-frontend/assets/25453621/365be30c-7327-4d84-bfbf-1512be70ac62)

