### PR TITLE
fix(Pipelines): set pipeline card title to 80%

### DIFF
--- a/src/workspaces/features/PipelineCard/PipelineCard.tsx
+++ b/src/workspaces/features/PipelineCard/PipelineCard.tsx
@@ -25,10 +25,12 @@ const PipelineCard = ({ pipeline, workspace }: PipelineCardProps) => {
       }}
       title={
         <div className="flex justify-between">
-          {pipeline.name}
-          {pipeline.lastRuns.items[0] && (
-            <PipelineRunStatusBadge run={pipeline.lastRuns.items[0]} />
-          )}
+          <span className="max-w-[80%]">{pipeline.name}</span>
+          <div>
+            {pipeline.lastRuns.items[0] && (
+              <PipelineRunStatusBadge run={pipeline.lastRuns.items[0]} />
+            )}
+          </div>
         </div>
       }
       subtitle={


### PR DESCRIPTION
Fix glitch on pipelines list views.

## Changes

Please list / describe the changes in the codebase for the reviewer(s).

- Set pipeline card title  width at 80%

## How/what to test

Create/edit a pipeline with a long title and check if the pipeline status is correctly displayed.

## Screenshots / screencast

![image](https://github.com/BLSQ/openhexa-frontend/assets/25453621/a6f72efe-7b1b-4f97-b0f0-efeea7f7ae72)