### PR TITLE
feat(Workspaces): restrict workspace creation to superuser

### DIFF
--- a/src/workspaces/features/SidebarMenu/SidebarMenu.tsx
+++ b/src/workspaces/features/SidebarMenu/SidebarMenu.tsx
@@ -170,18 +170,22 @@ const SidebarMenu = (props: SidebarMenuProps) => {
             <div className="flex w-full items-center justify-between px-4 py-2 text-sm font-medium tracking-wide text-gray-500 opacity-90">
               {t("Your workspaces")}
 
-              <button
-                type="button"
-                onClick={() => setDialogOpen(true)}
-                title={t("Create a new workspace")}
-                className="text-gray-400 hover:text-gray-600"
-              >
-                <PlusCircleIcon className="h-5 w-5 " />
-              </button>
-              <CreateWorkspaceDialog
-                open={isDialogOpen}
-                onClose={() => setDialogOpen(false)}
-              />
+              {me.permissions.createWorkspace && (
+                <>
+                  <button
+                    type="button"
+                    onClick={() => setDialogOpen(true)}
+                    title={t("Create a new workspace")}
+                    className="text-gray-400 hover:text-gray-600"
+                  >
+                    <PlusCircleIcon className="h-5 w-5 " />
+                  </button>
+                  <CreateWorkspaceDialog
+                    open={isDialogOpen}
+                    onClose={() => setDialogOpen(false)}
+                  />
+                </>
+              )}
             </div>
 
             <div className="max-h-96 overflow-y-auto">


### PR DESCRIPTION
Restrict workspace creation to super user.

## Changes

Please list / describe the changes in the codebase for the reviewer(s).

-  Display add button only for superuser

## How/what to test

Connect with a non super user, the add button on the sidebar should be hidden.

## Screenshots / screencast

![image](https://github.com/BLSQ/openhexa-frontend/assets/25453621/6b34a32a-4ea2-4e6f-8802-6259c79762c0)
