### PR TITLE
fix(Pipelines): fix guide URL

### DIFF
--- a/src/workspaces/features/CreatePipelineDialog/CreatePipelineDialog.tsx
+++ b/src/workspaces/features/CreatePipelineDialog/CreatePipelineDialog.tsx
@@ -56,7 +56,7 @@ const CreatePipelineDialog = (props: CreatePipelineDialogProps) => {
           <code>openhexa</code> CLI using the{" "}
           <Link
             target="_blank"
-            href="https://github.com/BLSQ/openhexa-pipelines-v2/blob/main/HOWTO.md"
+            href="https://github.com/BLSQ/openhexa/wiki/Writing-OpenHexa-pipelines"
           >
             guide
           </Link>{" "}


### PR DESCRIPTION
We were still using the old HOWTO guide in the link in the pipeline create modal.

## Changes

- Replaced old howto by new wiki link