### PR TITLE
fix(Apollo): Set next fetch policy to "cache-and-network"

### DIFF
--- a/src/core/helpers/apollo.ts
+++ b/src/core/helpers/apollo.ts
@@ -123,6 +123,11 @@ const createApolloClient = (headers: IncomingHttpHeaders | null = null) => {
     ssrForceFetchDelay: 100, // in milliseconds
     link,
     cache,
+    defaultOptions: {
+      watchQuery: {
+        nextFetchPolicy: "cache-and-network",
+      },
+    },
   });
 };
 


### PR DESCRIPTION
By default, the first query on client side will try to take it from the cache and not fetch from the server (it works because we preload the data on the server)

But if we try to useQuery again after the first client side call, we use the `nextFetchPolicy` "cache-and-network" to display directly what's in the cache while we fetch the new results from the server
