### PR TITLE
fix(Pipelines): parse float/int parameter to string for select

### DIFF
--- a/src/workspaces/features/RunPipelineDialog/ParameterField.tsx
+++ b/src/workspaces/features/RunPipelineDialog/ParameterField.tsx
@@ -44,13 +44,17 @@ const ParameterField = (props: ParameterFieldProps) => {
     );
   }
   if (parameter.choices?.length) {
+    const choices =
+      parameter.type !== "str"
+        ? parameter.choices.map((choice: number) => String(choice))
+        : parameter.choices;
     return (
       <Select
         onChange={handleChange}
         value={value}
         required={Boolean(parameter.required)}
         multiple={parameter.multiple}
-        options={parameter.choices ?? []}
+        options={choices ?? []}
         getOptionLabel={(option) => option}
         onCreate={
           !parameter.choices


### PR DESCRIPTION
This PR intentds to fix  [issue](https://github.com/BLSQ/openhexa-team/issues/405) about broken search on parameter of type int/float that accept choices.
## Changes

Please list / describe the changes in the codebase for the reviewer(s).

- Parse options to string

## How/what to test
Open the dialog for running a pipeline with a parameter of type int/float that accept choices and try to search on the displayed select. 


![image](https://github.com/BLSQ/openhexa-frontend/assets/25453621/1cd8caed-251d-469f-beda-93fa9260fac7)
