### PR TITLE
fix(Sentry): Add an ErrorBoundary wrapping nextjs app

### DIFF
--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -49,6 +49,13 @@ Sentry.init({
   ],
   dsn: publicRuntimeConfig.SENTRY_DSN,
   environment: publicRuntimeConfig.SENTRY_ENVIRONMENT,
+  integrations: [
+    new Sentry.BrowserTracing({
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^\//],
+      // Add additional custom options here
+    }),
+  ],
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampler({ transactionContext }) {
     if (transactionContext.metadata?.requestPath?.startsWith("/ready")) {

--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -13,6 +13,7 @@ if (config) {
   Sentry.init({
     dsn: publicRuntimeConfig.SENTRY_DSN,
     environment: publicRuntimeConfig.SENTRY_ENVIRONMENT,
+    tracePropagationTargets: ["localhost"],
     // Adjust this value in production, or use tracesSampler for greater control
     tracesSampler({ transactionContext }) {
       if (transactionContext.metadata?.requestPath?.startsWith("/ready")) {

--- a/src/core/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/core/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,26 @@
+import { ErrorBoundary as SentryErrorBoundary } from "@sentry/nextjs";
+import Title from "../Title";
+
+export default function ErrorBoundary({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <SentryErrorBoundary
+      fallback={
+        <div className="flex h-screen w-screen flex-col items-center justify-center">
+          <div className="space-y-2 text-center font-sans text-3xl font-normal text-gray-600">
+            <p>Something went wrong.</p>
+            <p className="text-2xl font-light text-gray-500">
+              Try reloading the page and if the issue persists please contact
+              your OpenHexa administrators.
+            </p>
+          </div>
+        </div>
+      }
+    >
+      {children}
+    </SentryErrorBoundary>
+  );
+}

--- a/src/core/components/ErrorBoundary/index.ts
+++ b/src/core/components/ErrorBoundary/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ErrorBoundary";

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -11,6 +11,7 @@ import { useEffect } from "react";
 import * as Sentry from "@sentry/nextjs";
 import { Settings } from "luxon";
 import { MeProvider } from "identity/hooks/useMe";
+import ErrorBoundary from "core/components/ErrorBoundary/ErrorBoundary";
 
 // Set the default locale & timezone to be used on server and client.
 // This should be changed to use the correct lang and tz of the user when it's available.
@@ -29,17 +30,22 @@ function App({ Component, pageProps }: AppPropsWithLayout) {
     Sentry.setUser(me?.user ? { email: me.user.email, id: me.user.id } : null);
   }, [me]);
   return (
-    <MeProvider me={me}>
-      <NavigationProgress color="#002C5F" height={3} />
-      <ApolloProvider client={apolloClient}>
-        <Head>
-          <meta name="viewport" content="width=device-width, initial-scale=1" />
-          <meta name="description" content="" />
-        </Head>
-        {getLayout(<Component {...pageProps} />, pageProps)}
-        <AlertManager />
-      </ApolloProvider>
-    </MeProvider>
+    <ErrorBoundary>
+      <MeProvider me={me}>
+        <NavigationProgress color="#002C5F" height={3} />
+        <ApolloProvider client={apolloClient}>
+          <Head>
+            <meta
+              name="viewport"
+              content="width=device-width, initial-scale=1"
+            />
+            <meta name="description" content="" />
+          </Head>
+          {getLayout(<Component {...pageProps} />, pageProps)}
+          <AlertManager />
+        </ApolloProvider>
+      </MeProvider>
+    </ErrorBoundary>
   );
 }
 


### PR DESCRIPTION
 + configure the tracing to not try to send the Baggage header to the api

The goal is to avoid to have <unlabeled event> in Sentry

There is a new error page when there is a bug in the client code.
<img width="1804" alt="Screenshot 2023-06-08 at 15 44 10" src="https://github.com/BLSQ/openhexa-frontend/assets/1607549/8c483e55-3059-495e-8dfb-4a3bf85b079a">
