### PR TITLE
chore: Remove console.log & fix erorr in dev mode

### DIFF
--- a/server/index.mjs
+++ b/server/index.mjs
@@ -29,6 +29,7 @@ app.prepare().then(async () => {
           req.path.startsWith("/airflow") ||
           req.path.startsWith("/images") ||
           req.path.startsWith("/_next") ||
+          req.path.startsWith("/__nextjs") ||
           req.path === "/" ||
           req.path.startsWith("/ready");
 

--- a/src/pages/workspaces/[workspaceSlug]/notebooks.tsx
+++ b/src/pages/workspaces/[workspaceSlug]/notebooks.tsx
@@ -33,7 +33,6 @@ const WorkspaceNotebooksPage: NextPageWithLayout = (props: Props) => {
   useEffect(() => {
     let timeout: NodeJS.Timeout;
     if (!server?.ready) {
-      console.log("fetch server");
       timeout = setTimeout(() => {
         launchNotebookServer(client, workspaceSlug).then(setServer);
       }, 1000);
@@ -41,7 +40,6 @@ const WorkspaceNotebooksPage: NextPageWithLayout = (props: Props) => {
     return () => clearTimeout(timeout);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [server]);
-  console.log(server);
 
   if (!data?.workspace) {
     return null;


### PR DESCRIPTION
The `__next` prefix is necessary to let Nextjs replies to the requests when an error occurred in development (until now, it was forwarded to the backend that has no clue on what to do with this)