### PR TITLE
chore(Connections): change label for GCS buckets

### DIFF
--- a/src/workspaces/helpers/connection.tsx
+++ b/src/workspaces/helpers/connection.tsx
@@ -585,7 +585,7 @@ export const CONNECTION_TYPES = {
     Form: S3BucketForm,
   },
   [ConnectionType.Gcs]: {
-    label: "Google Cloud Bucket",
+    label: "Google GCS Bucket",
     color: "bg-blue-200",
     iconSrc: "/images/gcs.svg",
     Form: GCSBucketForm,


### PR DESCRIPTION
Nothing special, just a label change (Google GCS bucket instead of Google Cloud Bucket).