### PR TITLE
fix(Pipelines): add comparator function for parameters with choices

### DIFF
--- a/src/core/components/forms/Combobox/Combobox.tsx
+++ b/src/core/components/forms/Combobox/Combobox.tsx
@@ -33,7 +33,7 @@ export type ComboboxProps<T> = {
     clear: () => void;
   }) => ReactNode;
   loading?: boolean;
-  by?: keyof T & string;
+  by?: (keyof T & string) | ((a: T, z: T) => boolean);
   onOpen?: () => void;
   displayValue(value: T): string;
   onClose?: () => void;

--- a/src/core/components/forms/Combobox/MultiCombobox.tsx
+++ b/src/core/components/forms/Combobox/MultiCombobox.tsx
@@ -32,7 +32,7 @@ type MultiComboboxProps<T> = {
     clear: () => void;
   }) => ReactNode;
   loading?: boolean;
-  by?: keyof T & string;
+  by?: (keyof T & string) | ((a: T, z: T) => boolean);
   onOpen?: () => void;
   displayValue(value: T): ReactNode;
   onClose?: () => void;

--- a/src/core/components/forms/Select.tsx
+++ b/src/core/components/forms/Select.tsx
@@ -89,7 +89,7 @@ function Select<O>(props: SelectProps<O>) {
       className={className}
       onChange={onChange}
       displayValue={displayValue as any}
-      by={by}
+      by={by as any /* Otherwise typescript is not happy */}
       loading={loading}
       withPortal
     >

--- a/src/workspaces/features/RunPipelineDialog/ParameterField.tsx
+++ b/src/workspaces/features/RunPipelineDialog/ParameterField.tsx
@@ -56,6 +56,7 @@ const ParameterField = (props: ParameterFieldProps) => {
         multiple={parameter.multiple}
         options={choices ?? []}
         getOptionLabel={(option) => option}
+        by={(a, b) => a == b}
         onCreate={
           !parameter.choices
             ? (query) =>


### PR DESCRIPTION
Fix for [issue](https://github.com/BLSQ/openhexa-team/issues/440). This issue is related to the default comparator function used by the ComboBox component.

## Changes

Please list / describe the changes in the codebase for the reviewer(s).

- Allow user defined function in  MultiCombobox/combobox props

## How/what to test

Use a pipeline with int/float parameter with choices and check that a selected element is highlighted.

## Screenshots / screencast
[Screencast from 21.06.2023 10:25:23.webm](https://github.com/BLSQ/openhexa-frontend/assets/25453621/82f3cc40-e82f-4feb-8ef6-fe552cba368e)

