### PR TITLE
fix(Files): Do not display the target directory

### DIFF
--- a/public/locales/en/messages.json
+++ b/public/locales/en/messages.json
@@ -96,7 +96,6 @@
   "Delete": "Delete",
   "Delete version": "",
   "Description": "Description",
-  "Destination": "",
   "Disable": "",
   "Disable Two-Factor Authentication": "",
   "Done": "Done",

--- a/public/locales/fr/messages.json
+++ b/public/locales/fr/messages.json
@@ -98,7 +98,6 @@
   "Delete": "",
   "Delete version": "",
   "Description": "",
-  "Destination": "",
   "Disable": "",
   "Disable Two-Factor Authentication": "",
   "Done": "",

--- a/src/workspaces/features/UploadObjectDialog/UploadObjectDialog.generated.tsx
+++ b/src/workspaces/features/UploadObjectDialog/UploadObjectDialog.generated.tsx
@@ -1,16 +1,13 @@
 import * as Types from '../../../graphql-types';
 
 import { gql } from '@apollo/client';
-export type UploadObjectDialog_WorkspaceFragment = { __typename?: 'Workspace', slug: string, permissions: { __typename?: 'WorkspacePermissions', createObject: boolean }, bucket: { __typename?: 'Bucket', name: string } };
+export type UploadObjectDialog_WorkspaceFragment = { __typename?: 'Workspace', slug: string, permissions: { __typename?: 'WorkspacePermissions', createObject: boolean } };
 
 export const UploadObjectDialog_WorkspaceFragmentDoc = gql`
     fragment UploadObjectDialog_workspace on Workspace {
   slug
   permissions {
     createObject
-  }
-  bucket {
-    name
   }
 }
     `;

--- a/src/workspaces/features/UploadObjectDialog/UploadObjectDialog.tsx
+++ b/src/workspaces/features/UploadObjectDialog/UploadObjectDialog.tsx
@@ -3,11 +3,10 @@ import { ArrowUpTrayIcon } from "@heroicons/react/24/outline";
 import Button from "core/components/Button";
 import Dialog from "core/components/Dialog";
 import Dropzone from "core/components/Dropzone";
-import Field from "core/components/forms/Field";
 import { uploader } from "core/helpers/files";
 import useCacheKey from "core/hooks/useCacheKey";
 import useForm from "core/hooks/useForm";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { getBucketObjectUploadUrl } from "workspaces/helpers/bucket";
 import { UploadObjectDialog_WorkspaceFragment } from "./UploadObjectDialog.generated";
@@ -63,29 +62,19 @@ const UploadObjectDialog = (props: UploadObjectDialogProps) => {
     }
   }, [open]);
 
-  const directory = useMemo(
-    () => [workspace.bucket.name, prefix ?? ""].join("/"),
-    [prefix, workspace]
-  );
   return (
     <Dialog open={open} onClose={onClose}>
       <form onSubmit={form.handleSubmit}>
         <Dialog.Title onClose={onClose}>
           {t("Upload files in workspace")}
         </Dialog.Title>
-        <Dialog.Content className="space-y-3">
-          <Field label={t("Destination")} name="path" required>
-            <div className="rounded-md bg-gray-100 p-1 font-mono text-xs">
-              {directory}
-            </div>
-          </Field>
-          <Field label={t("Files")} name="files" required>
-            <Dropzone
-              onChange={(files) => form.setFieldValue("files", files)}
-              disabled={form.isSubmitting}
-              label={t("Drop files here or click to select")}
-            />
-          </Field>
+        <Dialog.Content>
+          <Dropzone
+            className="h-48"
+            onChange={(files) => form.setFieldValue("files", files)}
+            disabled={form.isSubmitting}
+            label={t("Drop files here or click to select")}
+          />
           {form.submitError && (
             <p className={"text-sm text-red-600"}>{form.submitError}</p>
           )}
@@ -121,9 +110,6 @@ UploadObjectDialog.fragments = {
       slug
       permissions {
         createObject
-      }
-      bucket {
-        name
       }
     }
   `,


### PR DESCRIPTION
It was confusing for users to see the target directory when they upload files through the interface.

## Changes

- I removed the display of the path in the dialog
<img width="2185" alt="Screenshot 2023-06-21 at 16 55 37" src="https://github.com/BLSQ/openhexa-frontend/assets/1607549/f6f9cec4-c5cf-445d-9aeb-c8e1c65e2955">


