### PR TITLE
fix(Files): The download of an object happens with a content-disposition:download

### DIFF
--- a/src/workspaces/helpers/bucket.ts
+++ b/src/workspaces/helpers/bucket.ts
@@ -41,10 +41,10 @@ export async function getBucketObjectDownloadUrl(
   }
 }
 
-export async function downloadURL(url: string, target?: string) {
+export async function downloadURL(url: string, target: string = "") {
   const anchor = document.createElement("a");
   anchor.href = url;
-  anchor.target = target || "_blank";
+  anchor.target = target;
   document.body.appendChild(anchor);
   anchor.click();
   document.body.removeChild(anchor);


### PR DESCRIPTION
When users wanted to download files, some triggered a the browser to download the object directly while other opened a new windows with the content of the file. 

We changed this behaviour (mainly) on openhexa-app:  https://github.com/BLSQ/openhexa-app/pull/490