### PR TITLE
fix(RunPipeline): Bool parameters are never required

### DIFF
--- a/public/locales/en/messages.json
+++ b/public/locales/en/messages.json
@@ -298,7 +298,6 @@
   "This pipeline has not been uploaded yet": "",
   "This pipeline will run using the latest version": "",
   "This pipeline will run using the same version": "",
-  "This switch must be checked": "",
   "This table has no columns": "",
   "This will enable the two-factor authentication using your email address. A one-time code will be sent to you every time you try to log in.": "",
   "This workspace does not have any connection.": "",

--- a/public/locales/fr/messages.json
+++ b/public/locales/fr/messages.json
@@ -300,7 +300,6 @@
   "This pipeline has not been uploaded yet": "",
   "This pipeline will run using the latest version": "",
   "This pipeline will run using the same version": "",
-  "This switch must be checked": "",
   "This table has no columns": "",
   "This will enable the two-factor authentication using your email address. A one-time code will be sent to you every time you try to log in.": "",
   "This workspace does not have any connection.": "",

--- a/src/workspaces/features/RunPipelineDialog/RunPipelineDialog.test.tsx
+++ b/src/workspaces/features/RunPipelineDialog/RunPipelineDialog.test.tsx
@@ -83,7 +83,7 @@ describe("RunPipelineDialog", () => {
     );
   });
 
-  it("does not call the runPipeline with a required bool not true", async () => {
+  it("calls the runPipeline with a required bool not checked", async () => {
     const pipeline = pipelineWithParameters([
       {
         code: "is_ok",
@@ -104,7 +104,7 @@ describe("RunPipelineDialog", () => {
 
     render(<RunPipelineDialog open pipeline={pipeline} onClose={() => {}} />);
     await submitForm(user);
-    expect(runPipelineMock).not.toHaveBeenCalled();
+    expect(runPipelineMock).toHaveBeenCalled();
   });
 
   it("calls the runPipeline with a optional int", async () => {

--- a/src/workspaces/features/RunPipelineDialog/RunPipelineDialog.tsx
+++ b/src/workspaces/features/RunPipelineDialog/RunPipelineDialog.tsx
@@ -93,14 +93,6 @@ const RunPipelineDialog = (props: RunPipelineDialogProps) => {
       }
 
       for (const parameter of version.parameters) {
-        if (
-          parameter.type === "bool" &&
-          parameter.required &&
-          !fields[parameter.code]
-        ) {
-          errors[parameter.code] = t("This switch must be checked");
-        }
-
         const val = fields[parameter.code];
         if (parameter.type === "int") {
           if (isNaN(val)) {
@@ -244,7 +236,7 @@ const RunPipelineDialog = (props: RunPipelineDialogProps) => {
               >
                 {parameters.map((param, i) => (
                   <Field
-                    required={param.required}
+                    required={param.required || param.type === "bool"}
                     key={i}
                     name={param.code}
                     label={param.name}


### PR DESCRIPTION
The SDK set all parameters are required by default. That's a state we do not want for the bool parameters (it would force the users to put them at true in the UI)