### PR TITLE
fix(Pipelines): allow scheduling for only pipelines without parameters

### DIFF
--- a/public/locales/en/messages.json
+++ b/public/locales/en/messages.json
@@ -217,6 +217,7 @@
   "Pipeline run": "",
   "Pipeline Run": "",
   "Pipeline versions": "",
+  "Pipeline with parameters cannot be scheduled": "",
   "Pipelines": "",
   "Please enter an email address": "",
   "Port": "",

--- a/public/locales/fr/messages.json
+++ b/public/locales/fr/messages.json
@@ -219,6 +219,7 @@
   "Pipeline run": "",
   "Pipeline Run": "",
   "Pipeline versions": "",
+  "Pipeline with parameters cannot be scheduled": "",
   "Pipelines": "",
   "Please enter an email address": "",
   "Port": "",

--- a/schema.graphql
+++ b/schema.graphql
@@ -1399,6 +1399,7 @@ type PipelinePermissions {
   delete: Boolean!
   run: Boolean!
   deleteVersion: Boolean!
+  schedule: Boolean!
 }
 
 type PipelineRecipient {

--- a/src/graphql-types.ts
+++ b/src/graphql-types.ts
@@ -7,7 +7,7 @@ export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> =
 export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string | number; output: string; }
+  ID: { input: string; output: string; }
   String: { input: string; output: string; }
   Boolean: { input: boolean; output: boolean; }
   Int: { input: number; output: number; }

--- a/src/graphql-types.ts
+++ b/src/graphql-types.ts
@@ -1889,6 +1889,7 @@ export type PipelinePermissions = {
   delete: Scalars['Boolean']['output'];
   deleteVersion: Scalars['Boolean']['output'];
   run: Scalars['Boolean']['output'];
+  schedule: Scalars['Boolean']['output'];
   update: Scalars['Boolean']['output'];
 };
 

--- a/src/pages/workspaces/[workspaceSlug]/pipelines/[pipelineCode]/index.tsx
+++ b/src/pages/workspaces/[workspaceSlug]/pipelines/[pipelineCode]/index.tsx
@@ -196,29 +196,35 @@ const WorkspacePipelinePage: NextPageWithLayout = (props: Props) => {
                 label={t("Enabled")}
                 accessor={(item) => Boolean(item.schedule)}
               />
-              <CronProperty
-                id="schedule"
-                accessor="schedule"
-                label={t("Schedule")}
-                help={t("The schedule value should follow the CRON syntax.")}
-                placeholder="0 15 * * *"
-                visible={(_, __, values) =>
-                  Boolean(values.enableScheduling || pipeline.schedule)
-                }
-                required={(_, __, values) => Boolean(values.enableScheduling)}
-              />
-              <WorkspaceMemberProperty
-                id="recipients"
-                label={t("Notification Recipients")}
-                accessor={(pipeline) => pipeline.recipients}
-                slug={workspace.slug}
-                multiple
-                defaultValue="-"
-                visible={(_, __, values) =>
-                  Boolean(values.enableScheduling || pipeline.schedule)
-                }
-              />
-            </DataCard.FormSection>
+                <SwitchProperty
+                  id="enableScheduling"
+                  label={t("Enabled")}
+                  accessor={(item) => Boolean(item.schedule)}
+                />
+                <CronProperty
+                  id="schedule"
+                  accessor="schedule"
+                  label={t("Schedule")}
+                  help={t("The schedule value should follow the CRON syntax.")}
+                  placeholder="0 15 * * *"
+                  visible={(_, __, values) =>
+                    Boolean(values.enableScheduling || pipeline.schedule)
+                  }
+                  required={(_, __, values) => Boolean(values.enableScheduling)}
+                />
+                <WorkspaceMemberProperty
+                  id="recipients"
+                  label={t("Notification Recipients")}
+                  accessor={(pipeline) => pipeline.recipients}
+                  slug={workspace.slug}
+                  multiple
+                  defaultValue="-"
+                  visible={(_, __, values) =>
+                    Boolean(values.enableScheduling || pipeline.schedule)
+                  }
+                />
+              </DataCard.FormSection>
+            )}
           </DataCard>
 
           <div>

--- a/src/pages/workspaces/[workspaceSlug]/pipelines/[pipelineCode]/index.tsx
+++ b/src/pages/workspaces/[workspaceSlug]/pipelines/[pipelineCode]/index.tsx
@@ -184,18 +184,14 @@ const WorkspacePipelinePage: NextPageWithLayout = (props: Props) => {
                 }
               </RenderProperty>
             </DataCard.FormSection>
-            <DataCard.FormSection
-              title={t("Scheduling")}
-              onSave={
-                pipeline.permissions.update ? onSaveScheduling : undefined
-              }
-              collapsible={false}
-            >
-              <SwitchProperty
-                id="enableScheduling"
-                label={t("Enabled")}
-                accessor={(item) => Boolean(item.schedule)}
-              />
+            {pipeline.permissions.schedule && (
+              <DataCard.FormSection
+                title={t("Scheduling")}
+                onSave={
+                  pipeline.permissions.update ? onSaveScheduling : undefined
+                }
+                collapsible={false}
+              >
                 <SwitchProperty
                   id="enableScheduling"
                   label={t("Enabled")}

--- a/src/pages/workspaces/[workspaceSlug]/pipelines/[pipelineCode]/index.tsx
+++ b/src/pages/workspaces/[workspaceSlug]/pipelines/[pipelineCode]/index.tsx
@@ -184,43 +184,55 @@ const WorkspacePipelinePage: NextPageWithLayout = (props: Props) => {
                 }
               </RenderProperty>
             </DataCard.FormSection>
-            {pipeline.permissions.schedule && (
-              <DataCard.FormSection
-                title={t("Scheduling")}
-                onSave={
-                  pipeline.permissions.update ? onSaveScheduling : undefined
-                }
-                collapsible={false}
-              >
-                <SwitchProperty
-                  id="enableScheduling"
-                  label={t("Enabled")}
-                  accessor={(item) => Boolean(item.schedule)}
-                />
-                <CronProperty
-                  id="schedule"
-                  accessor="schedule"
-                  label={t("Schedule")}
-                  help={t("The schedule value should follow the CRON syntax.")}
-                  placeholder="0 15 * * *"
-                  visible={(_, __, values) =>
-                    Boolean(values.enableScheduling || pipeline.schedule)
-                  }
-                  required={(_, __, values) => Boolean(values.enableScheduling)}
-                />
-                <WorkspaceMemberProperty
-                  id="recipients"
-                  label={t("Notification Recipients")}
-                  accessor={(pipeline) => pipeline.recipients}
-                  slug={workspace.slug}
-                  multiple
-                  defaultValue="-"
-                  visible={(_, __, values) =>
-                    Boolean(values.enableScheduling || pipeline.schedule)
-                  }
-                />
-              </DataCard.FormSection>
-            )}
+            <DataCard.FormSection
+              title={t("Scheduling")}
+              onSave={
+                pipeline.permissions.update && pipeline.permissions.schedule
+                  ? onSaveScheduling
+                  : undefined
+              }
+              collapsible={false}
+            >
+              {pipeline.permissions.schedule ? (
+                <>
+                  <SwitchProperty
+                    id="enableScheduling"
+                    label={t("Enabled")}
+                    accessor={(item) => Boolean(item.schedule)}
+                  />
+                  <CronProperty
+                    id="schedule"
+                    accessor="schedule"
+                    label={t("Schedule")}
+                    help={t(
+                      "The schedule value should follow the CRON syntax."
+                    )}
+                    placeholder="0 15 * * *"
+                    visible={(_, __, values) =>
+                      Boolean(values.enableScheduling || pipeline.schedule)
+                    }
+                    required={(_, __, values) =>
+                      Boolean(values.enableScheduling)
+                    }
+                  />
+                  <WorkspaceMemberProperty
+                    id="recipients"
+                    label={t("Notification Recipients")}
+                    accessor={(pipeline) => pipeline.recipients}
+                    slug={workspace.slug}
+                    multiple
+                    defaultValue="-"
+                    visible={(_, __, values) =>
+                      Boolean(values.enableScheduling || pipeline.schedule)
+                    }
+                  />
+                </>
+              ) : (
+                <p className="text-sm font-medium italic text-gray-500">
+                  {t("Pipeline with parameters cannot be scheduled")}
+                </p>
+              )}
+            </DataCard.FormSection>
           </DataCard>
 
           <div>

--- a/src/workspaces/graphql/queries.generated.tsx
+++ b/src/workspaces/graphql/queries.generated.tsx
@@ -62,7 +62,7 @@ export type WorkspacePipelinePageQueryVariables = Types.Exact<{
 }>;
 
 
-export type WorkspacePipelinePageQuery = { __typename?: 'Query', workspace?: { __typename?: 'Workspace', slug: string, name: string, permissions: { __typename?: 'WorkspacePermissions', manageMembers: boolean, update: boolean, launchNotebookServer: boolean }, countries: Array<{ __typename?: 'Country', flag: string, code: string }> } | null, pipeline?: { __typename?: 'Pipeline', id: string, code: string, name?: string | null, description?: string | null, schedule?: string | null, permissions: { __typename?: 'PipelinePermissions', run: boolean, update: boolean, deleteVersion: boolean }, currentVersion?: { __typename?: 'PipelineVersion', id: string, number: number, createdAt: any, parameters: Array<{ __typename?: 'PipelineParameter', name: string, code: string, required: boolean, help?: string | null, type: string, default?: any | null, choices?: Array<any> | null, multiple: boolean }>, user?: { __typename?: 'User', displayName: string } | null } | null, recipients: Array<{ __typename?: 'PipelineRecipient', user: { __typename?: 'User', id: string, displayName: string } }>, runs: { __typename?: 'PipelineRunPage', totalItems: number, totalPages: number, pageNumber: number, items: Array<{ __typename?: 'PipelineRun', id: string, executionDate?: any | null, duration?: number | null, triggerMode?: Types.PipelineRunTrigger | null, status: Types.PipelineRunStatus, version: { __typename?: 'PipelineVersion', number: number, id: string }, user?: { __typename?: 'User', id: string, email: string, displayName: string, avatar: { __typename?: 'Avatar', initials: string, color: string } } | null }> }, workspace?: { __typename?: 'Workspace', slug: string } | null } | null };
+export type WorkspacePipelinePageQuery = { __typename?: 'Query', workspace?: { __typename?: 'Workspace', slug: string, name: string, permissions: { __typename?: 'WorkspacePermissions', manageMembers: boolean, update: boolean, launchNotebookServer: boolean }, countries: Array<{ __typename?: 'Country', flag: string, code: string }> } | null, pipeline?: { __typename?: 'Pipeline', id: string, code: string, name?: string | null, description?: string | null, schedule?: string | null, permissions: { __typename?: 'PipelinePermissions', run: boolean, update: boolean, schedule: boolean, deleteVersion: boolean }, currentVersion?: { __typename?: 'PipelineVersion', id: string, number: number, createdAt: any, parameters: Array<{ __typename?: 'PipelineParameter', name: string, code: string, required: boolean, help?: string | null, type: string, default?: any | null, choices?: Array<any> | null, multiple: boolean }>, user?: { __typename?: 'User', displayName: string } | null } | null, recipients: Array<{ __typename?: 'PipelineRecipient', user: { __typename?: 'User', id: string, displayName: string } }>, runs: { __typename?: 'PipelineRunPage', totalItems: number, totalPages: number, pageNumber: number, items: Array<{ __typename?: 'PipelineRun', id: string, executionDate?: any | null, duration?: number | null, triggerMode?: Types.PipelineRunTrigger | null, status: Types.PipelineRunStatus, version: { __typename?: 'PipelineVersion', number: number, id: string }, user?: { __typename?: 'User', id: string, email: string, displayName: string, avatar: { __typename?: 'Avatar', initials: string, color: string } } | null }> }, workspace?: { __typename?: 'Workspace', slug: string } | null } | null };
 
 export type WorkspacePipelineStartPageQueryVariables = Types.Exact<{
   workspaceSlug: Types.Scalars['String']['input'];
@@ -329,6 +329,9 @@ export const WorkspacePipelinePageDocument = gql`
     name
     description
     schedule
+    permissions {
+      schedule
+    }
     currentVersion {
       id
       number

--- a/src/workspaces/graphql/queries.graphql
+++ b/src/workspaces/graphql/queries.graphql
@@ -85,6 +85,9 @@ query WorkspacePipelinePage(
     name
     description
     schedule
+    permissions {
+      schedule
+    }
     currentVersion {
       id
       number


### PR DESCRIPTION
A short, meaningful PR description. Explain the goal of the PR and the ideas behind it.

## Changes

Please list / describe the changes in the codebase for the reviewer(s).

- display schedule section only when the pipelines has no parameters.


## How/what to test


## Screenshots / screencast

Pipeline without parameters

![image](https://github.com/BLSQ/openhexa-frontend/assets/25453621/50ca2701-0b87-429d-8139-298ef58c7163)

Pipeline with parameters
![image](https://github.com/BLSQ/openhexa-frontend/assets/25453621/f1d9a935-43fd-4b2c-8e86-c185f915e43e)
