### PR TITLE
fix(Connections): Wrong permission was checked to display the create a connection dialog

### DIFF
--- a/public/locales/en/messages.json
+++ b/public/locales/en/messages.json
@@ -216,7 +216,7 @@
   "Passwords are not the same": "",
   "Pending": "",
   "Pending invitations": "",
-  "Permissions denied": "",
+  "Permission denied": "",
   "Pipeline": "",
   "Pipeline Metadata": "",
   "Pipeline run": "",

--- a/public/locales/fr/messages.json
+++ b/public/locales/fr/messages.json
@@ -218,7 +218,7 @@
   "Passwords are not the same": "",
   "Pending": "",
   "Pending invitations": "",
-  "Permissions denied": "",
+  "Permission denied": "",
   "Pipeline": "",
   "Pipeline Metadata": "",
   "Pipeline run": "",

--- a/src/pages/workspaces/[workspaceSlug]/connections/index.tsx
+++ b/src/pages/workspaces/[workspaceSlug]/connections/index.tsx
@@ -83,7 +83,7 @@ const WorkspaceConnectionsPage: NextPageWithLayout = (props: Props) => {
             {workspace.connections.length === 0 ? (
               <div className="text-center text-gray-500">
                 <div>{t("This workspace does not have any connection.")}</div>
-                {workspace.permissions.update && (
+                {workspace.permissions.createConnection && (
                   <Button
                     variant="secondary"
                     onClick={() => setOpenModal(true)}

--- a/src/workspaces/features/CreateConnectionDialog/CreateConnectionDialog.tsx
+++ b/src/workspaces/features/CreateConnectionDialog/CreateConnectionDialog.tsx
@@ -145,7 +145,7 @@ export default function CreateConnectionDialog({
       } else if (
         errors.find((x) => x === CreateConnectionError.PermissionDenied)
       ) {
-        throw new Error(t("Permissions denied"));
+        throw new Error(t("Permission denied"));
       }
     },
   });
@@ -226,12 +226,10 @@ export default function CreateConnectionDialog({
                 required
               />
               <connection.Form form={form} />
-              {form.submitError && (
-                <p className={"my-2 text-sm text-red-600"}>
-                  {form.submitError}
-                </p>
-              )}
             </div>
+            {form.submitError && (
+              <p className={"my-2 text-sm text-red-600"}>{form.submitError}</p>
+            )}
           </Dialog.Content>
 
           <Dialog.Actions>

--- a/src/workspaces/graphql/queries.generated.tsx
+++ b/src/workspaces/graphql/queries.generated.tsx
@@ -111,7 +111,7 @@ export type ConnectionsPageQueryVariables = Types.Exact<{
 }>;
 
 
-export type ConnectionsPageQuery = { __typename?: 'Query', workspace?: { __typename?: 'Workspace', slug: string, name: string, permissions: { __typename?: 'WorkspacePermissions', update: boolean, manageMembers: boolean, launchNotebookServer: boolean }, connections: Array<{ __typename?: 'Connection', id: string, description?: string | null, name: string, type: Types.ConnectionType, slug: string, updatedAt?: any | null, permissions: { __typename?: 'ConnectionPermissions', update: boolean, delete: boolean } }>, countries: Array<{ __typename?: 'Country', flag: string, code: string }> } | null };
+export type ConnectionsPageQuery = { __typename?: 'Query', workspace?: { __typename?: 'Workspace', slug: string, name: string, permissions: { __typename?: 'WorkspacePermissions', update: boolean, createConnection: boolean, manageMembers: boolean, launchNotebookServer: boolean }, connections: Array<{ __typename?: 'Connection', id: string, description?: string | null, name: string, type: Types.ConnectionType, slug: string, updatedAt?: any | null, permissions: { __typename?: 'ConnectionPermissions', update: boolean, delete: boolean } }>, countries: Array<{ __typename?: 'Country', flag: string, code: string }> } | null };
 
 export type ConnectionPageQueryVariables = Types.Exact<{
   workspaceSlug: Types.Scalars['String']['input'];
@@ -691,6 +691,7 @@ export const ConnectionsPageDocument = gql`
     name
     permissions {
       update
+      createConnection
     }
     ...CreateConnectionDialog_workspace
     connections {

--- a/src/workspaces/graphql/queries.graphql
+++ b/src/workspaces/graphql/queries.graphql
@@ -254,6 +254,7 @@ query ConnectionsPage($workspaceSlug: String!) {
     name
     permissions {
       update
+      createConnection
     }
     ...CreateConnectionDialog_workspace
     connections {


### PR DESCRIPTION
The permission has been changed : update -> createConnection

## How/what to test

Use an editor account and go to the connections page. The "create connection" should not be visible

