### PR TITLE
fix(Connections): Hide 'add connection' button for non-admins

### DIFF
--- a/src/pages/workspaces/[workspaceSlug]/connections/[connectionId].tsx
+++ b/src/pages/workspaces/[workspaceSlug]/connections/[connectionId].tsx
@@ -125,7 +125,7 @@ const WorkspaceConnectionPage: NextPageWithLayout = ({
           <DataCard item={connection} className="divide-y-2 divide-gray-100">
             <div>
               <DataCard.FormSection
-                onSave={onSave}
+                onSave={connection.permissions.update ? onSave : undefined}
                 title={t("Information")}
                 className="space-y-4"
               >
@@ -152,9 +152,8 @@ const WorkspaceConnectionPage: NextPageWithLayout = ({
                   accessor="description"
                 />
               </DataCard.FormSection>
-              {workspace.permissions.update && (
-                <ConnectionFieldsSection connection={connection} />
-              )}
+
+              <ConnectionFieldsSection connection={connection} />
             </div>
           </DataCard>
         </WorkspaceLayout.PageContent>

--- a/src/pages/workspaces/[workspaceSlug]/connections/index.tsx
+++ b/src/pages/workspaces/[workspaceSlug]/connections/index.tsx
@@ -69,7 +69,7 @@ const WorkspaceConnectionsPage: NextPageWithLayout = (props: Props) => {
                 </Breadcrumbs.Part>
               </Breadcrumbs>
 
-              {workspace.permissions.update && (
+              {workspace.permissions.createConnection && (
                 <Button
                   leadingIcon={<PlusIcon className="w-4" />}
                   onClick={() => setOpenModal(true)}

--- a/src/workspaces/__tests__/connections.test.tsx
+++ b/src/workspaces/__tests__/connections.test.tsx
@@ -32,6 +32,7 @@ describe("Connections", () => {
     permissions: {
       update: true,
       delete: true,
+      createConnection: true,
       manageMembers: true,
     },
     connections: [],
@@ -67,6 +68,40 @@ describe("Connections", () => {
       },
     ],
   };
+  it("does not display the 'add connection' to non-admins", async () => {
+    const graphqlMocks = [
+      {
+        request: {
+          query: ConnectionsPageDocument,
+          variables: {
+            workspaceSlug: WORKSPACE.slug,
+          },
+        },
+        result: {
+          data: {
+            workspace: {
+              ...WORKSPACE,
+              permissions: {
+                ...WORKSPACE.permissions,
+                createConnection: false,
+              },
+            },
+          },
+        },
+      },
+    ];
+    render(
+      <TestApp mocks={graphqlMocks}>
+        <ConnectionsPage workspaceSlug={WORKSPACE.slug} />
+      </TestApp>
+    );
+
+    const btn = await screen.queryByText("Add connection", {
+      selector: "button",
+    }); // Wait for page rendering
+    expect(btn).not.toBeInTheDocument();
+  });
+
   it("renders the page without connections", async () => {
     const graphqlMocks = [
       {
@@ -216,6 +251,7 @@ describe("Connections", () => {
             workspace: {
               ...WORKSPACE,
               permissions: {
+                ...WORKSPACE.permissions,
                 update: true,
               },
               connections: [CONNECTION],


### PR DESCRIPTION
Permissions fixes for the connection.

## Changes

- Do not display the "Add connection" to non-admins
- Do not allow non-admins to edit connections
- Display the connection fields to all workspace members

