### PR TITLE
fix(Layout): Header was not sticky, make css simpler

### DIFF
--- a/src/workspaces/__tests__/__snapshots__/workspaces.test.tsx.snap
+++ b/src/workspaces/__tests__/__snapshots__/workspaces.test.tsx.snap
@@ -225,7 +225,7 @@ exports[`Workspaces renders the workspace page 1`] = `
       </div>
     </div>
     <main
-      class="flex flex-1 flex-col overflow-y-hidden transition-all"
+      class="w-full"
     >
       <div
         class="sticky top-0 z-10 flex h-16 flex-shrink-0 items-center justify-between border-b border-gray-200 bg-white py-3 shadow group relative px-4 md:px-6 xl:px-10 2xl:px-12"
@@ -559,7 +559,7 @@ exports[`Workspaces shows the jupyterhub entry when user have the launchNotebook
       </div>
     </div>
     <main
-      class="flex flex-1 flex-col overflow-y-hidden transition-all"
+      class="w-full"
     >
       <div
         class="sticky top-0 z-10 flex h-16 flex-shrink-0 items-center justify-between border-b border-gray-200 bg-white py-3 shadow group relative px-4 md:px-6 xl:px-10 2xl:px-12"

--- a/src/workspaces/layouts/WorkspaceLayout/WorkspaceLayout.tsx
+++ b/src/workspaces/layouts/WorkspaceLayout/WorkspaceLayout.tsx
@@ -86,14 +86,7 @@ const WorkspaceLayout = (props: WorkspaceLayoutProps) => {
           />
         </div>
 
-        <main
-          className={clsx(
-            "flex flex-1 flex-col overflow-y-hidden transition-all",
-            className
-          )}
-        >
-          {children}
-        </main>
+        <main className={clsx("w-full", className)}>{children}</main>
         <div className="fixed bottom-6 right-6">
           <Help links={helpLinks}>
             <div className="flex h-12 w-12 items-center justify-center rounded-full bg-white text-3xl shadow-xl ring-1 ring-gray-500 ring-opacity-5 transition-all hover:bg-gray-50 hover:text-4xl">


### PR DESCRIPTION
The header of the workspace layout was not sticky anymore.
I was able to remove a few useless classes as well
