### PR TITLE
fix: Align vertically the label in description list

### DIFF
--- a/src/core/components/DataCard/__tests__/__snapshots__/DataCard.test.tsx.snap
+++ b/src/core/components/DataCard/__tests__/__snapshots__/DataCard.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`DataCard renders 1`] = `
                 class="grid grid-cols-5 gap-2 sm:gap-4"
               >
                 <dt
-                  class="flex text-sm font-medium text-gray-500 col-span-1"
+                  class="flex text-sm font-medium text-gray-500 col-span-1 items-center"
                 >
                   <span
                     class="inline"

--- a/src/core/components/DescriptionList/DescriptionList.tsx
+++ b/src/core/components/DescriptionList/DescriptionList.tsx
@@ -54,7 +54,8 @@ DescriptionList.Item = function Item({
       <dt
         className={clsx(
           "flex text-sm font-medium text-gray-500",
-          displayMode === DescriptionListDisplayMode.LABEL_LEFT && "col-span-1",
+          displayMode === DescriptionListDisplayMode.LABEL_LEFT &&
+            "col-span-1 items-center",
           displayMode === DescriptionListDisplayMode.LABEL_ABOVE &&
             "col-span-5",
         )}

--- a/src/core/components/DescriptionList/__snapshots__/DescriptionList.test.tsx.snap
+++ b/src/core/components/DescriptionList/__snapshots__/DescriptionList.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`DescriptionList renders a list with one item 1`] = `
       class="grid grid-cols-5 gap-2 sm:gap-4"
     >
       <dt
-        class="flex text-sm font-medium text-gray-500 col-span-1"
+        class="flex text-sm font-medium text-gray-500 col-span-1 items-center"
       >
         <span
           class="inline"
@@ -36,7 +36,7 @@ exports[`DescriptionList renders the list on multiple columns 1`] = `
       class="grid grid-cols-5 gap-2 sm:gap-4"
     >
       <dt
-        class="flex text-sm font-medium text-gray-500 col-span-1"
+        class="flex text-sm font-medium text-gray-500 col-span-1 items-center"
       >
         <span
           class="inline"
@@ -54,7 +54,7 @@ exports[`DescriptionList renders the list on multiple columns 1`] = `
       class="grid grid-cols-5 gap-2 sm:gap-4"
     >
       <dt
-        class="flex text-sm font-medium text-gray-500 col-span-1"
+        class="flex text-sm font-medium text-gray-500 col-span-1 items-center"
       >
         <span
           class="inline"

--- a/src/visualizations/__tests__/__snapshots__/visualizations.test.tsx.snap
+++ b/src/visualizations/__tests__/__snapshots__/visualizations.test.tsx.snap
@@ -173,7 +173,7 @@ exports[`Visualization renders a visualization info page  1`] = `
                     class="grid grid-cols-5 gap-2 sm:gap-4"
                   >
                     <dt
-                      class="flex text-sm font-medium text-gray-500 col-span-1"
+                      class="flex text-sm font-medium text-gray-500 col-span-1 items-center"
                     >
                       <span
                         class="inline"
@@ -251,7 +251,7 @@ exports[`Visualization renders a visualization info page  1`] = `
                     class="grid grid-cols-5 gap-2 sm:gap-4"
                   >
                     <dt
-                      class="flex text-sm font-medium text-gray-500 col-span-1"
+                      class="flex text-sm font-medium text-gray-500 col-span-1 items-center"
                     >
                       <span
                         class="inline"
@@ -273,7 +273,7 @@ exports[`Visualization renders a visualization info page  1`] = `
                     class="grid grid-cols-5 gap-2 sm:gap-4"
                   >
                     <dt
-                      class="flex text-sm font-medium text-gray-500 col-span-1"
+                      class="flex text-sm font-medium text-gray-500 col-span-1 items-center"
                     >
                       <span
                         class="inline"
@@ -293,7 +293,7 @@ exports[`Visualization renders a visualization info page  1`] = `
                     class="grid grid-cols-5 gap-2 sm:gap-4"
                   >
                     <dt
-                      class="flex text-sm font-medium text-gray-500 col-span-1"
+                      class="flex text-sm font-medium text-gray-500 col-span-1 items-center"
                     >
                       <span
                         class="inline"
@@ -311,7 +311,7 @@ exports[`Visualization renders a visualization info page  1`] = `
                     class="grid grid-cols-5 gap-2 sm:gap-4"
                   >
                     <dt
-                      class="flex text-sm font-medium text-gray-500 col-span-1"
+                      class="flex text-sm font-medium text-gray-500 col-span-1 items-center"
                     >
                       <span
                         class="inline"
@@ -333,7 +333,7 @@ exports[`Visualization renders a visualization info page  1`] = `
                     class="grid grid-cols-5 gap-2 sm:gap-4"
                   >
                     <dt
-                      class="flex text-sm font-medium text-gray-500 col-span-1"
+                      class="flex text-sm font-medium text-gray-500 col-span-1 items-center"
                     >
                       <span
                         class="inline"


### PR DESCRIPTION
Align the label of the description list vertically

<img width="1711" alt="Screenshot 2023-09-13 at 09 54 58" src="https://github.com/BLSQ/openhexa-frontend/assets/1607549/adf4ebe4-a950-4d06-84d4-516177a2cbaa">
