### PR TITLE
feat(Connections): hide gcs connection service_account_key value

### DIFF
--- a/src/workspaces/helpers/connections/gcs.tsx
+++ b/src/workspaces/helpers/connections/gcs.tsx
@@ -55,6 +55,7 @@ export default {
       code: "service_account_key",
       name: "Service Account Key",
       required: true,
+      secret: true,
     },
   ],
 };


### PR DESCRIPTION
Hide gcs connection service_account_key value

## Changes

Please list / describe the changes in the codebase for the reviewer(s).

- Define service_account_key as a secret in GCS connection definition


## Screenshots / screencast
![image](https://github.com/BLSQ/openhexa-frontend/assets/25453621/bc72f9de-ca2c-4b1a-80e9-9fc8ae858469)