### PR TITLE
chore(Nextjs): Add a trailing slash to nextjs urls

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -30,7 +30,7 @@ const config = {
 
   poweredByHeader: false, // Disable 'x-powered-by' header
   reactStrictMode: true,
-  trailingSlash: false,
+  trailingSlash: true,
   i18n,
 };
 


### PR DESCRIPTION
To be able to make relative links in the wiki, we'd need to have trailing slash in the urls.
NextJS provides this feature but we need to test if it works well in legacy mode and with the navigation in the workspaces.

