### PR TITLE
fix(Pipelines): Fix issues on multiple choice param

### DIFF
--- a/src/workspaces/features/RunPipelineDialog/ParameterField.test.tsx
+++ b/src/workspaces/features/RunPipelineDialog/ParameterField.test.tsx
@@ -147,6 +147,33 @@ describe("ParameterField", () => {
     expect(onChange).toHaveBeenCalledWith("2");
   });
 
+  it("renders a select if param have choices and multiple", async () => {
+    const onChange = jest.fn();
+    const user = userEvent.setup();
+    const param = {
+      code: "choice_param",
+      name: "choice__param",
+      type: "int",
+      default: null,
+      required: false,
+      choices: [1, 2, 3],
+      multiple: true,
+    };
+
+    render(
+      <ParameterField
+        parameter={param}
+        value={param.default}
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(await screen.findByTestId("combobox-button"));
+    await user.click(await screen.findByText("2"));
+
+    expect(onChange).toHaveBeenCalledWith(["2"]);
+  });
+
   it("renders a textarea for param multiple", async () => {
     const onChange = jest.fn();
     const param = {

--- a/src/workspaces/features/RunPipelineDialog/ParameterField.tsx
+++ b/src/workspaces/features/RunPipelineDialog/ParameterField.tsx
@@ -21,13 +21,13 @@ const ParameterField = (props: ParameterFieldProps) => {
     (value: any) => {
       if (parameter.multiple && (value === null || value === undefined)) {
         return onChange([]);
-      } else if (parameter.multiple) {
+      } else if (parameter.multiple && !parameter.choices) {
         onChange(value.split("\n"));
       } else {
         onChange(value);
       }
     },
-    [onChange, parameter.multiple],
+    [onChange, parameter.multiple, parameter.choices],
   );
 
   if (parameter.type === "bool") {
@@ -47,7 +47,7 @@ const ParameterField = (props: ParameterFieldProps) => {
     return (
       <Select
         onChange={handleChange}
-        value={value}
+        value={value || []}
         required={Boolean(parameter.required)}
         multiple={parameter.multiple}
         options={choices ?? []}


### PR DESCRIPTION
Fix for https://github.com/BLSQ/openhexa-team/issues/594.

## Changes

Please list / describe the changes in the codebase for the reviewer(s).

- Check if parameter is multiple and doesn't have choices
- Use empty array as default when parameter default choice is not defined.

## How/what to test

Create a pipeline with a parameter of type int/float, multiple and have choices.

## Screenshots / screencast

[Screencast from 10-25-2023 03:46:52 PM.webm](https://github.com/BLSQ/openhexa-frontend/assets/25453621/f5c9c301-8625-49f3-8076-5df8c0bf0881)

