### PR TITLE
fix(PipelineDialog): prevent display of empty value on picker

### DIFF
--- a/src/workspaces/features/RunPipelineDialog/ParameterField.tsx
+++ b/src/workspaces/features/RunPipelineDialog/ParameterField.tsx
@@ -6,7 +6,6 @@ import Textarea from "core/components/forms/Textarea/Textarea";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import WorkspaceConnectionPicker from "../WorkspaceConnectionPicker/WorkspaceConnectionPicker";
-import { ConnectionType } from "graphql-types";
 import { isConnectionParameter } from "workspaces/helpers/pipelines";
 
 type ParameterFieldProps = {
@@ -48,7 +47,7 @@ const ParameterField = (props: ParameterFieldProps) => {
       <WorkspaceConnectionPicker
         workspaceSlug={workspaceSlug || ""}
         value={value ?? []}
-        onChange={(option) => handleChange(option)}
+        onChange={(option) => handleChange(option?.slug)}
         withPortal
         type={parameter.type}
       />

--- a/src/workspaces/features/RunPipelineDialog/RunPipelineDialog.tsx
+++ b/src/workspaces/features/RunPipelineDialog/RunPipelineDialog.tsx
@@ -7,7 +7,7 @@ import Dialog from "core/components/Dialog";
 import Field from "core/components/forms/Field";
 import useCacheKey from "core/hooks/useCacheKey";
 import useForm from "core/hooks/useForm";
-import { ConnectionType, PipelineVersion } from "graphql-types";
+import { PipelineVersion } from "graphql-types";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";

--- a/src/workspaces/features/WorkspaceConnectionPicker/WorkspaceConnectionPicker.test.tsx
+++ b/src/workspaces/features/WorkspaceConnectionPicker/WorkspaceConnectionPicker.test.tsx
@@ -54,7 +54,7 @@ describe("WorkspaceConnectionPicker", () => {
       <WorkspaceConnectionPicker
         workspaceSlug={WORKSPACE.slug}
         onChange={onChange}
-        value={[]}
+        value={""}
       />,
     );
 

--- a/src/workspaces/features/WorkspaceConnectionPicker/WorkspaceConnectionPicker.tsx
+++ b/src/workspaces/features/WorkspaceConnectionPicker/WorkspaceConnectionPicker.tsx
@@ -15,7 +15,7 @@ type Option = {
 };
 
 type WorkspaceConnectionPickerProps = {
-  value: Option | Option[];
+  value?: string;
   workspaceSlug: string;
   placeholder?: string;
   onChange(value?: Option): void;
@@ -74,6 +74,10 @@ const WorkspaceConnectionPicker = (props: WorkspaceConnectionPickerProps) => {
     [],
   );
 
+  const comboBoxValue = useMemo(() => {
+    return options.find((option) => option.slug === value) ?? null;
+  }, [value, options]);
+
   return (
     <Combobox
       required={required}
@@ -81,13 +85,13 @@ const WorkspaceConnectionPicker = (props: WorkspaceConnectionPickerProps) => {
       loading={loading}
       withPortal={withPortal}
       displayValue={displayValue}
-      by={(a: Option, b: Option) => a.id === b.id}
+      by="name"
       onInputChange={useCallback(
         (event: any) => setQuery(event.target.value),
         [],
       )}
       placeholder={placeholder}
-      value={value as any}
+      value={comboBoxValue as any}
       onClose={useCallback(() => setQuery(""), [])}
       disabled={disabled}
     >

--- a/src/workspaces/features/WorkspaceConnectionPicker/__snapshots__/WorkspaceConnectionPicker.test.tsx.snap
+++ b/src/workspaces/features/WorkspaceConnectionPicker/__snapshots__/WorkspaceConnectionPicker.test.tsx.snap
@@ -37,21 +37,6 @@ exports[`WorkspaceConnectionPicker display all connections 1`] = `
           class="ml-1 flex items-center gap-0.5 rounded-r-md text-gray-400 focus:outline-none"
         >
           <svg
-            aria-hidden="true"
-            class="h-4 w-4 cursor-pointer hover:text-gray-500"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="1.5"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M6 18L18 6M6 6l12 12"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            />
-          </svg>
-          <svg
             class="animate-spin h-5 w-5"
             data-testid="spinner"
             fill="none"

--- a/src/workspaces/helpers/pipelines.ts
+++ b/src/workspaces/helpers/pipelines.ts
@@ -13,7 +13,6 @@ import {
   PipelineParameter,
   PipelineVersion,
 } from "graphql-types";
-import Connections from "./connections";
 
 export async function updatePipeline(pipelineId: string, values: any) {
   const client = getApolloClient();
@@ -95,7 +94,7 @@ export const convertParametersToPipelineInput = (
     } else if (parameter.type === "str" && parameter.multiple && val) {
       params[parameter.code] = val.filter((s: string) => s !== "");
     } else if (isConnectionParameter(parameter.type) && val) {
-      params[parameter.code] = val.slug;
+      params[parameter.code] = val;
     } else {
       params[parameter.code] = val;
     }


### PR DESCRIPTION
Filter and display the correct connection from pipeline run config.

A short, meaningful PR description. Explain the goal of the PR and the ideas behind it.

## Changes

Please list / describe the changes in the codebase for the reviewer(s).

- Filter and display connection based on the value (if empty return null)
- Change WorkspaceConnectionPicker value type (from Option to string)
- Pass the connection slug to onChange method in ParameterField instead of connection object

## Screenshots / screencast

[Screencast from 11-22-2023 12:53:39 PM.webm](https://github.com/BLSQ/openhexa-frontend/assets/25453621/47053bc8-4288-4502-99c2-f92d7228f0ef)

