### PR TITLE
fix(ConnectionPicker): use id for connection identifier

### DIFF
--- a/src/workspaces/features/WorkspaceConnectionPicker/WorkspaceConnectionPicker.tsx
+++ b/src/workspaces/features/WorkspaceConnectionPicker/WorkspaceConnectionPicker.tsx
@@ -85,7 +85,7 @@ const WorkspaceConnectionPicker = (props: WorkspaceConnectionPickerProps) => {
       loading={loading}
       withPortal={withPortal}
       displayValue={displayValue}
-      by="name"
+      by="id"
       onInputChange={useCallback(
         (event: any) => setQuery(event.target.value),
         [],


### PR DESCRIPTION
Use id for connection identifier in combobox.