### PR TITLE
fix(files): Replace the default value of query by an empty string

### DIFF
--- a/src/pages/workspaces/[workspaceSlug]/files/[[...prefix]].tsx
+++ b/src/pages/workspaces/[workspaceSlug]/files/[[...prefix]].tsx
@@ -248,7 +248,7 @@ export const getServerSideProps = createGetServerSideProps({
     const prefixArr = (ctx.params?.prefix as string[]) ?? [];
     const prefix = prefixArr.length > 0 ? prefixArr.join("/") + "/" : "";
     const page = ctx.query?.page ? parseInt(ctx.query.page as string, 10) : 1;
-    const searchQuery = (ctx.query?.q as string) ?? null;
+    const searchQuery = (ctx.query?.q as string) ?? "";
     const perPage = ctx.query?.perPage
       ? parseInt(ctx.query.perPage as string, 10)
       : ENTRIES_PER_PAGE;


### PR DESCRIPTION
My latest change was to replace the empty string by null. It passes the null value to the server and boom.
