### PR TITLE
fix(Pipelines): null & empty values for int and float should be ignored

### DIFF
--- a/src/workspaces/features/RunPipelineDialog/RunPipelineDialog.test.tsx
+++ b/src/workspaces/features/RunPipelineDialog/RunPipelineDialog.test.tsx
@@ -151,7 +151,7 @@ describe("RunPipelineDialog", () => {
     await submitForm(user);
     expect(runPipelineMock).toHaveBeenCalledWith(
       pipeline.id,
-      { int: null },
+      {},
       pipeline.currentVersion.number,
       false,
     );

--- a/src/workspaces/helpers/pipelines.ts
+++ b/src/workspaces/helpers/pipelines.ts
@@ -85,16 +85,16 @@ export const convertParametersToPipelineInput = (
         params[parameter.code] = val
           .filter((v: string) => v !== "")
           .map((v: string) => parseInt(v, 10));
-      } else {
-        params[parameter.code] = val !== null ? parseInt(val, 10) : null;
+      } else if (val !== null && val !== "") {
+        params[parameter.code] = parseInt(val, 10);
       }
     } else if (parameter.type === "float") {
       if (parameter.multiple && val) {
         params[parameter.code] = val
           .filter((v: string) => v !== "")
           .map((v: string) => parseFloat(v));
-      } else {
-        params[parameter.code] = val !== null ? parseFloat(val) : null;
+      } else if (val !== null && val !== "") {
+        params[parameter.code] = parseFloat(val);
       }
     } else if (parameter.type === "str" && parameter.multiple && val) {
       params[parameter.code] = val.filter((s: string) => s !== "");


### PR DESCRIPTION
If the int or float parameter value was "" it would call `parseInt` and set the value as NaN.
