### PR TITLE
fix(Pipelines): Only display the 'run again' button for finished runs

### DIFF
--- a/src/pages/workspaces/[workspaceSlug]/pipelines/[pipelineCode]/runs/[runId].tsx
+++ b/src/pages/workspaces/[workspaceSlug]/pipelines/[pipelineCode]/runs/[runId].tsx
@@ -156,12 +156,14 @@ const WorkspacePipelineRunPage: NextPageWithLayout = (props: Props) => {
               <Time datetime={run.executionDate} />
             </Breadcrumbs.Part>
           </Breadcrumbs>
-          <Button
-            leadingIcon={<ArrowPathIcon className="h-4 w-4" />}
-            onClick={() => setIsRunPipelineDialogOpen(true)}
-          >
-            {t("Run again")}
-          </Button>
+          {isFinished && (
+            <Button
+              leadingIcon={<ArrowPathIcon className="h-4 w-4" />}
+              onClick={() => setIsRunPipelineDialogOpen(true)}
+            >
+              {t("Run again")}
+            </Button>
+          )}
         </WorkspaceLayout.Header>
 
         <WorkspaceLayout.PageContent>


### PR DESCRIPTION
Otherwise the run again dialog refreshes the params values every second or so.
