### PR TITLE
fix(Files): hide upload and create button for viewer

### DIFF
--- a/src/pages/workspaces/[workspaceSlug]/files/[[...prefix]].tsx
+++ b/src/pages/workspaces/[workspaceSlug]/files/[[...prefix]].tsx
@@ -202,20 +202,24 @@ export const WorkspaceFilesPage: NextPageWithLayout = (props: Props) => {
                 </div>
               )}
             </Popover>
-            <Button
-              variant="secondary"
-              leadingIcon={<FolderPlusIcon className="h-4 w-4" />}
-              onClick={() => setCreateFolderDialogOpen(true)}
-            >
-              {t("Create a folder")}
-            </Button>
-            <Button
-              variant="primary"
-              leadingIcon={<ArrowUpTrayIcon className="h-4 w-4" />}
-              onClick={() => setUploadDialogOpen(true)}
-            >
-              {t("Upload files")}
-            </Button>
+            {workspace.permissions.createObject && (
+              <>
+                <Button
+                  variant="secondary"
+                  leadingIcon={<FolderPlusIcon className="h-4 w-4" />}
+                  onClick={() => setCreateFolderDialogOpen(true)}
+                >
+                  {t("Create a folder")}
+                </Button>
+                <Button
+                  variant="primary"
+                  leadingIcon={<ArrowUpTrayIcon className="h-4 w-4" />}
+                  onClick={() => setUploadDialogOpen(true)}
+                >
+                  {t("Upload files")}
+                </Button>
+              </>
+            )}
           </div>
           <Block className="divide divide-y divide-gray-100">
             <BucketExplorer

--- a/src/workspaces/graphql/queries.generated.tsx
+++ b/src/workspaces/graphql/queries.generated.tsx
@@ -807,6 +807,9 @@ export const WorkspaceFilesPageDocument = gql`
         ...BucketExplorer_objects
       }
     }
+    permissions {
+      createObject
+    }
   }
 }
     ${BucketExplorer_WorkspaceFragmentDoc}

--- a/src/workspaces/graphql/queries.graphql
+++ b/src/workspaces/graphql/queries.graphql
@@ -322,6 +322,9 @@ query WorkspaceFilesPage(
         ...BucketExplorer_objects
       }
     }
+    permissions{
+      createObject
+    }
   }
 }
 


### PR DESCRIPTION
On the bucket explorer, a member with viewer role can interact with the create folder and upload files button, even though they cannot create/upload object, but an error will be show if they try to. (see https://github.com/BLSQ/openhexa-team/issues/714)

## Changes

Please list / describe the changes in the codebase for the reviewer(s).

- Check if user has createObject permission on the workspace before showing Upload files/ Create folder buttons.

## Screenshots / screencast

![image](https://github.com/BLSQ/openhexa-frontend/assets/25453621/2e7c2607-040f-4f94-b8b9-4fb11d837b60)
