### PR TITLE
fix(Sidebar): In compact mode, the sidebar labels were under the tables

### DIFF
--- a/src/workspaces/__tests__/__snapshots__/workspaces.test.tsx.snap
+++ b/src/workspaces/__tests__/__snapshots__/workspaces.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`Workspaces renders the workspace page 1`] = `
     class="flex min-h-screen w-screen"
   >
     <div
-      class="fixed h-screen bg-gray-800 transition-all duration-75 w-64 2xl:w-72"
+      class="fixed h-screen bg-gray-800 transition-all duration-75 z-20 w-64 2xl:w-72"
     >
       <div
         class="relative z-20 flex h-full flex-col"
@@ -331,7 +331,7 @@ exports[`Workspaces shows the jupyterhub entry when user have the launchNotebook
     class="flex min-h-screen w-screen"
   >
     <div
-      class="fixed h-screen bg-gray-800 transition-all duration-75 w-64 2xl:w-72"
+      class="fixed h-screen bg-gray-800 transition-all duration-75 z-20 w-64 2xl:w-72"
     >
       <div
         class="relative z-20 flex h-full flex-col"

--- a/src/workspaces/layouts/WorkspaceLayout/WorkspaceLayout.tsx
+++ b/src/workspaces/layouts/WorkspaceLayout/WorkspaceLayout.tsx
@@ -78,7 +78,7 @@ const WorkspaceLayout = (props: WorkspaceLayoutProps) => {
       <div className="flex min-h-screen w-screen">
         <div
           className={clsx(
-            "fixed h-screen bg-gray-800 transition-all duration-75",
+            "fixed h-screen bg-gray-800 transition-all duration-75 z-20",
             isSidebarOpen ? "w-64 2xl:w-72" : "w-16",
           )}
         >


### PR DESCRIPTION
This can be tested on /files & /database pages
![CleanShot 2024-02-15 at 11 29 17@2x](https://github.com/BLSQ/openhexa-frontend/assets/1607549/54e3b91f-7b4c-4ec7-b190-dfab203337c2)

