### PR TITLE
fix(Workspaces): fix bar url on cron property

### DIFF
--- a/src/workspaces/features/CronProperty/CronProperty.tsx
+++ b/src/workspaces/features/CronProperty/CronProperty.tsx
@@ -52,7 +52,7 @@ const CronProperty = (props: CronPropertyProps) => {
             <Link
               href={
                 "https://crontab.guru/#" +
-                  property.formValue?.replaceAll(" ", "_") ?? ""
+                (property.formValue?.replaceAll(" ", "_") ?? "")
               }
               target="_blank"
             >


### PR DESCRIPTION
On the CronProperty component the link to crontab.guru app is not correctly set when there's no cron expression to evaluate (it shows https://crontab.guru#undefined).

Changes  : 

- Add parenthesis to evaluate nullish coalescing operator before assigning.