### PR TITLE
fix(Pipelines): Remove the 'v' in front of the version's name in the PipelinePicker

### DIFF
--- a/src/workspaces/features/PipelineVersionPicker/PipelineVersionPicker.tsx
+++ b/src/workspaces/features/PipelineVersionPicker/PipelineVersionPicker.tsx
@@ -49,9 +49,9 @@ const PipelineVersionPicker = (props: PipelineVersionPickerProps) => {
   const displayValue = useCallback(
     (option: Option) =>
       option
-        ? `V${option.name} - ${DateTime.fromISO(
-            option.createdAt,
-          ).toLocaleString(DateTime.DATETIME_MED)}`
+        ? `${option.name} - ${DateTime.fromISO(option.createdAt).toLocaleString(
+            DateTime.DATETIME_MED,
+          )}`
         : "",
     [],
   );


### PR DESCRIPTION
It was related to our previous version's names that were numbers. Now, it's a free text