### PR TITLE
fix(Connections): check if connection fields is defined

### DIFF
--- a/src/workspaces/features/CreateConnectionDialog/CreateConnectionDialog.tsx
+++ b/src/workspaces/features/CreateConnectionDialog/CreateConnectionDialog.tsx
@@ -110,11 +110,11 @@ export default function CreateConnectionDialog({
             fields:
               connectionType !== ConnectionType.Custom
                 ? convertFieldsToInput(connection, rest)
-                : rest.fields.map((field: FieldForm) => ({
+                : rest.fields?.map((field: FieldForm) => ({
                     code: field.code,
                     value: field.value,
                     secret: Boolean(field.secret),
-                  })),
+                  })) ?? [],
           },
         },
       });


### PR DESCRIPTION
When creating a custom connection if the user doesn't add fields, the following error is displayed :  _Cannot read properties of undefined (reading 'map')_ .

## Changes

Please list / describe the changes in the codebase for the reviewer(s).

- Add a check on connection fields
- Change 2

## How/what to test

A few words about what needs to be tested, along with specific testing instructions if needed.

## Screenshots / screencast

![Screenshot 2024-06-27 at 11 20 24](https://github.com/BLSQ/openhexa-frontend/assets/25453621/b88de6b4-5680-4593-bd82-9bcd44c482bf)

