### PR TITLE
chore: Remove Plausible

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ The following environment variables should be provided at run time:
 - `SENTRY_TRACES_SAMPLE_RATE`: the [Sentry](https://sentry.io/) sampling rate of traces
 - `SENTRY_DSN`: the [Sentry](https://sentry.io/) DSN
 - `SENTRY_ENVIRONMENT`: the [Sentry](https://sentry.io/) environment tag
-- `TELEMETRY_ID`: The domain ID created on Plausible.io where the telemetry data will be sent
 
 ### Code style
 

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,5 +1,4 @@
 import BaseDocument, { Html, Head, Main, NextScript } from "next/document";
-import Script from "next/script";
 
 class Document extends BaseDocument {
   render() {
@@ -7,13 +6,6 @@ class Document extends BaseDocument {
       <Html className="h-full bg-gray-100">
         <Head>
           <link rel="icon" href="/static/img/favicon.png" />
-          {process.env.TELEMETRY_ID && (
-            <Script
-              src="https://plausible.io/js/script.js"
-              strategy="lazyOnload"
-              data-domain={process.env.TELEMETRY_ID}
-            />
-          )}
         </Head>
         <body className="h-full">
           <Main />


### PR DESCRIPTION
Now that we have the analytics implemented in the backend, we do not need Plausible on the frontend anymore.