### PR TITLE
feat(FileUploader): prevent user to inadvertently click on upload

### DIFF
--- a/src/workspaces/features/UploadObjectDialog/UploadObjectDialog.tsx
+++ b/src/workspaces/features/UploadObjectDialog/UploadObjectDialog.tsx
@@ -52,7 +52,7 @@ const UploadObjectDialog = (props: UploadObjectDialogProps) => {
         onProgress: setProgress,
       });
       clearCache();
-      onClose();
+      handleClose();
     },
   });
 
@@ -62,9 +62,14 @@ const UploadObjectDialog = (props: UploadObjectDialogProps) => {
     }
   }, [open]);
 
+  const handleClose = () => {
+    form.resetForm();
+    onClose();
+  };
+
   return (
-    <Dialog onSubmit={form.handleSubmit} open={open} onClose={onClose}>
-      <Dialog.Title onClose={onClose}>
+    <Dialog onSubmit={form.handleSubmit} open={open} onClose={handleClose}>
+      <Dialog.Title onClose={handleClose}>
         {t("Upload files in workspace")}
       </Dialog.Title>
       <Dialog.Content>
@@ -82,14 +87,14 @@ const UploadObjectDialog = (props: UploadObjectDialogProps) => {
         <div className="flex items-center justify-between gap-3">
           <Button
             variant="white"
-            onClick={onClose}
+            onClick={handleClose}
             disabled={form.isSubmitting}
           >
             {t("Cancel")}
           </Button>
           <Button
             type="submit"
-            disabled={form.isSubmitting}
+            disabled={!form.isDirty || form.isSubmitting}
             leadingIcon={<ArrowUpTrayIcon className="h-4 w-4" />}
           >
             {form.isSubmitting


### PR DESCRIPTION
Users do not know they can click on the upload box in the dialog to open a file picker

## Changes

Please list / describe the changes in the codebase for the reviewer(s).

- Disable upload button until a file is selected.
- Reset form state when Dialog is closed



## Screenshots / screencast


https://github.com/user-attachments/assets/91b36268-9333-4f01-a323-b834f984549c

