### PR TITLE
fix(Apollo): Set initialFetchPolicy to 'cache-first' and implement a basic nextFetchPolicy

### DIFF
--- a/src/core/helpers/apollo.ts
+++ b/src/core/helpers/apollo.ts
@@ -199,8 +199,10 @@ export const getApolloClient = (
     // Get existing cache, loaded during client side data fetching
     const existingCache = client.extract();
 
-    // Merge the existing cache into data passed from getStaticProps/getServerSideProps
-    const data = merge(initialState, existingCache, {
+    // We have an existing cache when we navigate between pages in the frontend.
+    // We merge the existing cache with the new data passed from getStaticProps/getServerSideProps (that is more likely to be fresh)
+    // We use the existing cache as the base because it contains the data from the queries that have already been fetched
+    const data = merge(existingCache, initialState, {
       // combine arrays using object equality (like in sets)
       arrayMerge: (destinationArray, sourceArray) => [
         ...sourceArray,

--- a/src/core/helpers/apollo.ts
+++ b/src/core/helpers/apollo.ts
@@ -137,7 +137,42 @@ const createApolloClient = (headers: IncomingHttpHeaders | null = null) => {
     cache,
     defaultOptions: {
       watchQuery: {
-        fetchPolicy: "cache-and-network",
+        initialFetchPolicy: "cache-first",
+        nextFetchPolicy(
+          currentFetchPolicy,
+          {
+            // Either "after-fetch" or "variables-changed", indicating why the
+            // nextFetchPolicy function was invoked.
+            reason,
+            // The rest of the options (currentFetchPolicy === options.fetchPolicy).
+            options,
+            // The original value of options.fetchPolicy, before nextFetchPolicy was
+            // applied for the first time.
+            initialFetchPolicy,
+            // The ObservableQuery associated with this client.watchQuery call.
+            observable,
+          },
+        ) {
+          // When variables change, the default behavior is to reset
+          // options.fetchPolicy to context.initialFetchPolicy. If you omit this logic,
+          // your nextFetchPolicy function can override this default behavior to
+          // prevent options.fetchPolicy from changing in this case.
+          if (reason === "variables-changed") {
+            return initialFetchPolicy;
+          }
+
+          if (
+            currentFetchPolicy === "network-only" ||
+            currentFetchPolicy === "cache-and-network"
+          ) {
+            // Demote the network policies (except "no-cache") to "cache-first"
+            // after the first request.
+            return "cache-first";
+          }
+
+          // Leave all other fetch policies unchanged.
+          return currentFetchPolicy;
+        },
       },
     },
   });


### PR DESCRIPTION
The nextFetchPolicy is taken from the Apollo documentation

## Context

We saw that when navigating between pages using links the Apollo cache was not used to render the data even though it was pre-populated by the SSR of the app. This was caused by the `cache-and-network` setting that always fires a request to the server to ensure to have the freshest data possible. It's not relevant for the initial load since we can be certain it is fresh.

`cache-and-network`
> Apollo Client executes the full query against both the cache and your GraphQL server. The query automatically updates if the result of the server-side query modifies cached fields.Provides a fast response while also helping to keep cached data consistent with server data.
