### PR TITLE
fix(Datasets): do not throw when column total values is not available

### DIFF
--- a/src/datasets/features/DatasetVersionFileColumns/DatasetVersionFileColumns.tsx
+++ b/src/datasets/features/DatasetVersionFileColumns/DatasetVersionFileColumns.tsx
@@ -1,5 +1,5 @@
 import { gql, useQuery } from "@apollo/client";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import Spinner from "core/components/Spinner";
 import { MetadataAttribute } from "graphql/types";
 import { camelCase } from "lodash";
@@ -77,6 +77,13 @@ const DatasetVersionFileColumns = (props: DatasetVersionFileColumnsProps) => {
     };
   }, [data]);
 
+  const renderAttributePercentage = useCallback((value: number) => {
+    if (!total) {
+      return "";
+    }
+    return `(${percentage(value, total)}%)`;
+  }, []);
+
   if (loading)
     return (
       <div className="flex justify-center items-center h-24 p-4">
@@ -114,12 +121,12 @@ const DatasetVersionFileColumns = (props: DatasetVersionFileColumnsProps) => {
             <DescriptionList compact>
               <DescriptionList.Item label={t("Distinct")}>
                 <code className="font-mono text-sm text-gray-600">
-                  {`${column.distinctValues} (${percentage(column.distinctValues, total)}%)`}
+                  {`${column.distinctValues} ${renderAttributePercentage(column.distinctValues)}`}
                 </code>
               </DescriptionList.Item>
               <DescriptionList.Item label={t("Missing")} className="gap-4">
                 <code className="font-mono text-sm text-gray-600 ">
-                  {`${column.missingValues} (${percentage(column.missingValues, total)}%)`}
+                  {`${column.missingValues} ${renderAttributePercentage(column.missingValues)}`}
                 </code>
               </DescriptionList.Item>
             </DescriptionList>

--- a/src/datasets/features/DatasetVersionFileColumns/DatasetVersionFileColumns.tsx
+++ b/src/datasets/features/DatasetVersionFileColumns/DatasetVersionFileColumns.tsx
@@ -1,5 +1,5 @@
 import { gql, useQuery } from "@apollo/client";
-import { useCallback, useMemo } from "react";
+import { useMemo } from "react";
 import Spinner from "core/components/Spinner";
 import { MetadataAttribute } from "graphql/types";
 import { camelCase } from "lodash";
@@ -77,13 +77,6 @@ const DatasetVersionFileColumns = (props: DatasetVersionFileColumnsProps) => {
     };
   }, [data]);
 
-  const renderAttributePercentage = useCallback((value: number) => {
-    if (!total) {
-      return "";
-    }
-    return `(${percentage(value, total)}%)`;
-  }, []);
-
   if (loading)
     return (
       <div className="flex justify-center items-center h-24 p-4">
@@ -121,12 +114,12 @@ const DatasetVersionFileColumns = (props: DatasetVersionFileColumnsProps) => {
             <DescriptionList compact>
               <DescriptionList.Item label={t("Distinct")}>
                 <code className="font-mono text-sm text-gray-600">
-                  {`${column.distinctValues} ${renderAttributePercentage(column.distinctValues)}`}
+                  {`${column.distinctValues} (${total ? `${percentage(column.distinctValues, total)}%` : "-"})`}
                 </code>
               </DescriptionList.Item>
               <DescriptionList.Item label={t("Missing")} className="gap-4">
                 <code className="font-mono text-sm text-gray-600 ">
-                  {`${column.missingValues} ${renderAttributePercentage(column.missingValues)}`}
+                  {`${column.missingValues} (${total ? `${percentage(column.missingValues, total)}%` : "-"})`}
                 </code>
               </DescriptionList.Item>
             </DescriptionList>

--- a/src/datasets/helpers/dataset.ts
+++ b/src/datasets/helpers/dataset.ts
@@ -318,9 +318,9 @@ export async function deleteDataset(datasetId: string) {
   }
 }
 
-export function percentage(part: number, total: number): number {
+export function percentage(part: number, total: number): number | null {
   if (total <= 0 || isNaN(total)) {
-    throw new Error("Total must be a valid positive number");
+    return null;
   }
   return Number(((part / total) * 100).toFixed(2));
 }

--- a/src/datasets/helpers/dataset.ts
+++ b/src/datasets/helpers/dataset.ts
@@ -318,9 +318,9 @@ export async function deleteDataset(datasetId: string) {
   }
 }
 
-export function percentage(part: number, total: number): number | null {
+export function percentage(part: number, total: number): number {
   if (total <= 0 || isNaN(total)) {
-    return null;
+    throw new Error("Total must be a valid positive number");
   }
   return Number(((part / total) * 100).toFixed(2));
 }


### PR DESCRIPTION
Return empty string when total count is not available.

## Changes

Please list / describe the changes in the codebase for the reviewer(s).

- percentage helper return null when total is NaN or negative.

## How/what to test

Open an old dataset file columns section, the percentage for the stats should be not displayed if not available. 

## Screenshots / screencast


https://github.com/user-attachments/assets/de5edaf6-6ed3-4085-ab70-13f6f079a30d
