### PR TITLE
fix: HEXA-1147 props in Datagrid

### DIFF
--- a/src/core/components/DataGrid/DataGrid.tsx
+++ b/src/core/components/DataGrid/DataGrid.tsx
@@ -268,63 +268,88 @@ function DataGrid(props: DataGridProps) {
           className={clsx(fixedLayout && "table-fixed")}
         >
           <TableHead>
-            {headerGroups.map((headerGroup, i) => (
-              <TableRow {...headerGroup.getHeaderGroupProps()}>
-                {headerGroup.headers.map((column) => (
-                  <TableCell
-                    heading
-                    className={column.headerClassName}
-                    {...column.getHeaderProps(column.getSortByToggleProps())}
-                    spacing={spacing}
-                  >
-                    {column.hideLabel ? (
-                      <span className="sr-only">{column.render("Header")}</span>
-                    ) : (
-                      <>
-                        {column.render("Header")}
-                        {column.isSorted && i === headerGroups.length - 1 && (
-                          <div
-                            className={clsx(
-                              "ml-2 inline-block w-3 flex-none rounded bg-gray-200 text-gray-900 group-hover:bg-gray-300",
-                            )}
-                          >
-                            {column.isSortedDesc ? (
-                              <ChevronDownIcon
-                                className="h-3 w-3"
-                                aria-hidden="true"
-                              />
-                            ) : (
-                              <ChevronUpIcon
-                                className="h-3 w-3"
-                                aria-hidden="true"
-                              />
-                            )}
-                          </div>
+            {headerGroups.map((headerGroup, i) => {
+              const rowProps = headerGroup.getHeaderGroupProps();
+              const { key: rowKey, ...otherRowProps } = rowProps;
+              return (
+                <TableRow key={rowKey} {...otherRowProps}>
+                  {headerGroup.headers.map((column) => {
+                    const cellProps = column.getHeaderProps(
+                      column.getSortByToggleProps(),
+                    );
+                    const { key: cellKey, ...otherCellProps } = cellProps;
+                    return (
+                      <TableCell
+                        key={cellKey}
+                        heading
+                        className={column.headerClassName}
+                        {...otherCellProps}
+                        spacing={spacing}
+                      >
+                        {column.hideLabel ? (
+                          <span className="sr-only">
+                            {column.render("Header")}
+                          </span>
+                        ) : (
+                          <>
+                            {column.render("Header")}
+                            {column.isSorted &&
+                              i === headerGroups.length - 1 && (
+                                <div
+                                  className={clsx(
+                                    "ml-2 inline-block w-3 flex-none rounded bg-gray-200 text-gray-900 group-hover:bg-gray-300",
+                                  )}
+                                >
+                                  {column.isSortedDesc ? (
+                                    <ChevronDownIcon
+                                      className="h-3 w-3"
+                                      aria-hidden="true"
+                                    />
+                                  ) : (
+                                    <ChevronUpIcon
+                                      className="h-3 w-3"
+                                      aria-hidden="true"
+                                    />
+                                  )}
+                                </div>
+                              )}
+                          </>
                         )}
-                      </>
-                    )}
-                  </TableCell>
-                ))}
-              </TableRow>
-            ))}
+                      </TableCell>
+                    );
+                  })}
+                </TableRow>
+              );
+            })}
           </TableHead>
           <TableBody {...getTableBodyProps()}>
             {page.map((row, i) => {
               prepareRow(row);
+              const rowProps = row.getRowProps();
+              const { key: rowKey, ...otherRowProps } = rowProps;
               return (
-                <TableRow {...row.getRowProps()} className={rowClassName}>
-                  {row.cells.map((cell) => (
-                    <TableCell
-                      {...cell.getCellProps({
-                        className: cell.column.className,
-                      })}
-                      spacing={spacing}
-                    >
-                      <CellContextProvider cell={cell}>
-                        {cell.render("Cell")}
-                      </CellContextProvider>
-                    </TableCell>
-                  ))}
+                <TableRow
+                  key={rowKey}
+                  {...otherRowProps}
+                  className={rowClassName}
+                >
+                  {row.cells.map((cell) => {
+                    const cellProps = cell.getCellProps({
+                      className: cell.column.className,
+                    });
+                    const { key: cellKey, ...otherCellProps } = cellProps;
+                    return (
+                      <TableCell
+                        key={cellKey}
+                        {...otherCellProps}
+                        spacing={spacing}
+                      >
+                        <CellContextProvider cell={cell}>
+                          {cell.render("Cell")}
+                        </CellContextProvider>
+                      </TableCell>
+                    );
+                  })}
                 </TableRow>
               );
             })}


### PR DESCRIPTION
Rendering Datagrids is causing error logs in dev because the key is part of the destruct props.

## Changes

- Extract the key from the props and pass it independently

## How/what to test

No more error logs for Datagrids

## Screenshots / screencast

<img width="1490" alt="Screenshot 2024-12-19 at 22 49 44" src="https://github.com/user-attachments/assets/76c8a239-9549-4fd8-a6cf-87b9afbec737" />


