### PR TITLE
fix: HEXA-1153 scrolling dataset versions

### DIFF
--- a/src/core/components/Listbox/Listbox.tsx
+++ b/src/core/components/Listbox/Listbox.tsx
@@ -129,10 +129,17 @@ const IntersectionObserverWrapper = ({
   onScrollBottom: () => void;
 }) => {
   const endRef = useRef<HTMLDivElement>(null);
-  const list = useIntersectionObserver(endRef, {});
+  const [isMounted, setIsMounted] = useState(false);
+  const list = useIntersectionObserver(endRef, {
+    freezeOnceVisible: !isMounted,
+  });
 
   useEffect(() => {
-    if (list?.isIntersecting && onScrollBottom) {
+    setIsMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (isMounted && list?.isIntersecting) {
       onScrollBottom();
     }
   }, [onScrollBottom, list]);

--- a/src/core/components/Listbox/Listbox.tsx
+++ b/src/core/components/Listbox/Listbox.tsx
@@ -7,7 +7,7 @@ import {
 } from "@headlessui/react";
 import { ChevronUpDownIcon } from "@heroicons/react/24/outline";
 import clsx from "clsx";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "next-i18next";
 import { sameWidthModifier } from "core/helpers/popper";
 import { usePopper } from "react-popper";
@@ -128,23 +128,16 @@ const IntersectionObserverWrapper = ({
 }: {
   onScrollBottom: () => void;
 }) => {
-  const endRef = useRef<HTMLDivElement>(null);
-  const [isMounted, setIsMounted] = useState(false);
-  const list = useIntersectionObserver(endRef, {
-    freezeOnceVisible: !isMounted,
-  });
+  const [endRef, setEndRef] = useState<HTMLDivElement | null>(null);
+  const list = useIntersectionObserver(endRef, {});
 
   useEffect(() => {
-    setIsMounted(true);
-  }, []);
-
-  useEffect(() => {
-    if (isMounted && list?.isIntersecting) {
+    if (endRef && list?.isIntersecting) {
       onScrollBottom();
     }
-  }, [onScrollBottom, list]);
+  }, [onScrollBottom, list, endRef]);
 
-  return <div ref={endRef}></div>;
+  return <div ref={setEndRef}></div>;
 };
 
 export default Listbox;

--- a/src/core/components/Listbox/Listbox.tsx
+++ b/src/core/components/Listbox/Listbox.tsx
@@ -128,16 +128,16 @@ const IntersectionObserverWrapper = ({
 }: {
   onScrollBottom: () => void;
 }) => {
-  const [endRef, setEndRef] = useState<HTMLDivElement | null>(null);
-  const list = useIntersectionObserver(endRef, {});
+  const [lastElement, setLastElement] = useState<Element | null>(null);
+  const list = useIntersectionObserver(lastElement, {});
 
   useEffect(() => {
-    if (endRef && list?.isIntersecting) {
+    if (lastElement && list?.isIntersecting) {
       onScrollBottom();
     }
-  }, [onScrollBottom, list, endRef]);
+  }, [onScrollBottom, list, lastElement]);
 
-  return <div ref={setEndRef}></div>;
+  return <div ref={setLastElement}></div>;
 };
 
 export default Listbox;

--- a/src/core/components/Listbox/Listbox.tsx
+++ b/src/core/components/Listbox/Listbox.tsx
@@ -51,15 +51,6 @@ const Listbox = (props: ListboxProps) => {
     modifiers: MODIFIERS,
   });
 
-  const endRef = useRef<HTMLDivElement>(null);
-  const list = useIntersectionObserver(endRef, {});
-
-  useEffect(() => {
-    if (list?.isIntersecting && onScrollBottom) {
-      onScrollBottom();
-    }
-  }, [onScrollBottom, list]);
-
   return (
     <UIListbox value={value} onChange={onChange} by={by}>
       {({ open }) => (
@@ -83,47 +74,70 @@ const Listbox = (props: ListboxProps) => {
               <ChevronUpDownIcon className="h-5 w-5" aria-hidden="true" />
             </span>
           </UIListboxButton>
-          <Portal>
-            <UIListboxOptions
-              ref={setPopperElement}
-              className={
-                "z-10 flex max-h-72 w-full flex-col rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm"
-              }
-              style={styles.popper}
-              {...attributes.popper}
-            >
-              <div className="flex-1 overflow-auto">
-                {options.map((option) => (
-                  <UIListboxOption
-                    key={option[by]}
-                    value={option}
-                    className={({ focus }) =>
-                      clsx(
-                        "relative cursor-default select-none px-2 py-2",
-                        focus ? "bg-blue-500 text-white" : "text-gray-900",
-                      )
-                    }
-                  >
-                    {({ focus, selected }) => (
-                      <span
-                        className={clsx(
-                          "flex-1 truncate",
-                          selected && "font-semibold",
-                        )}
-                      >
-                        {getOptionLabel(option)}
-                      </span>
-                    )}
-                  </UIListboxOption>
-                ))}
-                {onScrollBottom && <div ref={endRef}></div>}
-              </div>
-            </UIListboxOptions>
-          </Portal>
+          {open && (
+            <Portal>
+              <UIListboxOptions
+                ref={setPopperElement}
+                className={
+                  "z-10 flex max-h-72 w-full flex-col rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm"
+                }
+                style={styles.popper}
+                {...attributes.popper}
+              >
+                <div className="flex-1 overflow-auto">
+                  {options.map((option) => (
+                    <UIListboxOption
+                      key={option[by]}
+                      value={option}
+                      className={({ focus }) =>
+                        clsx(
+                          "relative cursor-default select-none px-2 py-2",
+                          focus ? "bg-blue-500 text-white" : "text-gray-900",
+                        )
+                      }
+                    >
+                      {({ focus, selected }) => (
+                        <span
+                          className={clsx(
+                            "flex-1 truncate",
+                            selected && "font-semibold",
+                          )}
+                        >
+                          {getOptionLabel(option)}
+                        </span>
+                      )}
+                    </UIListboxOption>
+                  ))}
+                  {onScrollBottom && (
+                    <IntersectionObserverWrapper
+                      onScrollBottom={onScrollBottom}
+                    />
+                  )}
+                </div>
+              </UIListboxOptions>
+            </Portal>
+          )}
         </div>
       )}
     </UIListbox>
   );
+};
+
+const IntersectionObserverWrapper = ({
+  onScrollBottom,
+}: {
+  onScrollBottom: () => void;
+}) => {
+  const endRef = useRef<HTMLDivElement>(null);
+  const list = useIntersectionObserver(endRef, {});
+
+  useEffect(() => {
+    if (list?.isIntersecting && onScrollBottom) {
+      onScrollBottom();
+    }
+  }, [onScrollBottom, list]);
+
+  return <div ref={endRef}></div>;
 };
 
 export default Listbox;

--- a/src/core/hooks/useIntersectionObserver.ts
+++ b/src/core/hooks/useIntersectionObserver.ts
@@ -1,11 +1,11 @@
-import { RefObject, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 interface Args extends IntersectionObserverInit {
   freezeOnceVisible?: boolean;
 }
 
 export default function useIntersectionObserver(
-  elementRef: RefObject<Element>,
+  element: Element | null,
   {
     threshold = 0,
     root = null,
@@ -22,22 +22,21 @@ export default function useIntersectionObserver(
   };
 
   useEffect(() => {
-    const node = elementRef?.current; // DOM Ref
     const hasIOSupport = !!window.IntersectionObserver;
 
-    if (!hasIOSupport || frozen || !node) {
+    if (!hasIOSupport || frozen || !element) {
       return;
     }
 
     const observerParams = { threshold, root, rootMargin };
     const observer = new IntersectionObserver(updateEntry, observerParams);
 
-    observer.observe(node);
+    observer.observe(element);
 
     return () => observer.disconnect();
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [elementRef, threshold, root, rootMargin, frozen]);
+  }, [element, threshold, root, rootMargin, frozen]);
 
   return entry;
 }

--- a/src/datasets/features/DatasetVersionPicker/DatasetVersionPicker.test.tsx
+++ b/src/datasets/features/DatasetVersionPicker/DatasetVersionPicker.test.tsx
@@ -31,7 +31,7 @@ const createMockData = (totalItems: number, itemsPerPage: number) => ({
 });
 
 describe("DatasetVersionPicker component", () => {
-  it("calls onScrollBottom when scrolling to the last element", async () => {
+  it("pull additional data when scrolling to the last element", async () => {
     const dataset = { id: faker.string.uuid() };
     const version = null;
 

--- a/src/datasets/features/DatasetVersionPicker/DatasetVersionPicker.test.tsx
+++ b/src/datasets/features/DatasetVersionPicker/DatasetVersionPicker.test.tsx
@@ -1,0 +1,76 @@
+import { useQuery } from "@apollo/client";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { faker } from "@faker-js/faker";
+import DatasetVersionPicker from "./DatasetVersionPicker";
+import "@testing-library/jest-dom";
+import { DateTime } from "luxon";
+import useIntersectionObserver from "core/hooks/useIntersectionObserver";
+
+jest.mock("@apollo/client", () => ({
+  __esModule: true,
+  useQuery: jest.fn(),
+  gql: jest.fn(() => "GQL"),
+}));
+
+jest.mock("core/hooks/useIntersectionObserver");
+
+const useQueryMock = useQuery as jest.Mock;
+const useIntersectionObserverMock = useIntersectionObserver as jest.Mock;
+
+const createMockData = (totalItems: number, itemsPerPage: number) => ({
+  dataset: {
+    versions: {
+      totalItems,
+      items: Array.from({ length: itemsPerPage }, () => ({
+        id: faker.string.uuid(),
+        name: faker.lorem.words(2),
+        createdAt: DateTime.now().toISO(),
+      })),
+    },
+  },
+});
+
+describe("DatasetVersionPicker component", () => {
+  it("calls onScrollBottom when scrolling to the last element", async () => {
+    const dataset = { id: faker.string.uuid() };
+    const version = null;
+
+    useQueryMock.mockReturnValue({
+      loading: false,
+      data: createMockData(20, 15),
+    });
+
+    let isIntersecting = false;
+    useIntersectionObserverMock.mockImplementation(() => ({
+      isIntersecting,
+    }));
+
+    render(
+      <DatasetVersionPicker
+        onChange={() => {}}
+        dataset={dataset}
+        version={version}
+      />,
+    );
+
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+
+    expect(screen.queryAllByRole("option")).toHaveLength(15);
+
+    useQueryMock.mockReturnValue({
+      loading: false,
+      data: createMockData(20, 20),
+    });
+
+    isIntersecting = true;
+    const dropdown = await screen.findByRole("listbox");
+    fireEvent.scroll(dropdown, {
+      target: { scrollTop: 2000 },
+    });
+
+    await waitFor(() => {
+      expect(screen.queryAllByRole("option")).toHaveLength(20);
+    });
+  });
+});


### PR DESCRIPTION
When scrolling on dataset versions only 10 are showing while we expect additional to reload
This is due to https://github.com/BLSQ/openhexa-frontend/pull/902 -> the upgrade made the options invisible in the DOM so the ref tracking the last element was null

## Changes

- Ensure the ref to the last element is non null by setting it in a component in the dropdown view
- A unit test to cover the fetching of that 

## How/what to test

The dataset dropdown fetches data as we scroll

## Screenshots / screencast

https://github.com/user-attachments/assets/52d32551-a889-4ec5-bfec-f88c62ee09fd


