### PR TITLE
fix: set default state for sidebar

### DIFF
--- a/src/pages/workspaces/[workspaceSlug]/files/[[...prefix]].tsx
+++ b/src/pages/workspaces/[workspaceSlug]/files/[[...prefix]].tsx
@@ -246,7 +246,8 @@ export const getServerSideProps = createGetServerSideProps({
     const perPage = ctx.query?.perPage
       ? parseInt(ctx.query.perPage as string, 10)
       : ENTRIES_PER_PAGE;
-    const showHiddenFiles = getCookie("show-hidden-files", ctx) === undefined;
+    const showHiddenFiles =
+      (await getCookie("show-hidden-files", ctx)) === undefined;
     const { data } = await client.query<
       WorkspaceFilesPageQuery,
       WorkspaceFilesPageQueryVariables

--- a/src/workspaces/layouts/WorkspaceLayout/WorkspaceLayout.tsx
+++ b/src/workspaces/layouts/WorkspaceLayout/WorkspaceLayout.tsx
@@ -56,7 +56,9 @@ const WorkspaceLayout = (props: WorkspaceLayoutProps) => {
   const [_, setLastWorkspace] = useLocalStorage("last-visited-workspace");
   const defaultSidebarOpen = getDefaultSidebarOpen();
 
-  const [isSidebarOpen, setSidebarOpen] = useState(true);
+  const [isSidebarOpen, setSidebarOpen] = useState(
+    !forceCompactSidebar && defaultSidebarOpen,
+  );
 
   useEffect(() => {
     setLastWorkspace(workspace.slug);
@@ -128,8 +130,8 @@ WorkspaceLayout.prefetch = async (
   client: CustomApolloClient,
 ) => {
   // Load the cookie value from the request to render it correctly on the server
-  cookieSidebarOpenState = hasCookie("sidebar-open", ctx)
-    ? getCookie("sidebar-open", ctx) === "true"
+  cookieSidebarOpenState = (await hasCookie("sidebar-open", ctx))
+    ? (await getCookie("sidebar-open", ctx)) === "true"
     : true;
   await Sidebar.prefetch(client);
 };


### PR DESCRIPTION
Related to issue [JIRA-1132](https://bluesquare.atlassian.net/jira/software/c/projects/HEXA/boards/330?assignee=712020%3A1d0055ff-af59-47b7-b48d-4d37e2a0d0b9&selectedIssue=HEXA-1132).  The Sidebar was always open even if we collapsed it.

## Changes

Please list / describe the changes in the codebase for the reviewer(s).

- Reset initial value for isSidebarOpen state (removed previously)
- Fix `cookieSidebarOpenState` that was changing value between server and client (see https://github.com/andreizanik/cookies-next?tab=readme-ov-file)

## How/what to test
Collapse the sidebar, change or refresh page, and check if it keeps its state.

## Screenshots / screencast


https://github.com/user-attachments/assets/52a774e8-7fe6-4c49-b3ae-0d6fd51e1f7a

