### PR TITLE
chore(Pipelines): Increase the width of the RunPipelineDialog

### DIFF
--- a/src/workspaces/features/RunPipelineDialog/RunPipelineDialog.tsx
+++ b/src/workspaces/features/RunPipelineDialog/RunPipelineDialog.tsx
@@ -230,6 +230,7 @@ const RunPipelineDialog = (props: RunPipelineDialogProps) => {
           onClose={onClose}
           centered={false}
           onSubmit={form.handleSubmit}
+          maxWidth={"max-w-2xl"}
         >
           <Dialog.Title>{t("Run pipeline")}</Dialog.Title>
           {!activeVersion ? (


### PR DESCRIPTION
The width of the dialog has been deleted recently. It makes the dialog ugly when there are more than a few parameters

