### PR TITLE
fix: duplicates in cache (HEXA-1171)

### DIFF
--- a/src/core/helpers/apollo.ts
+++ b/src/core/helpers/apollo.ts
@@ -76,6 +76,10 @@ const CACHE_CONFIG: InMemoryCacheConfig = {
     Pipeline: {
       merge: true,
     },
+    PipelineParameter: {
+      merge: true,
+      keyFields: ["code"],
+    },
   },
 };
 


### PR DESCRIPTION
PipelineParameters can not be merged in the Apollo cache because they don't have an `id`

Use the `code` as the `id`

Thanks @qgerome for the help on this one :) 