### PR TITLE
fix(React): fix hydration error because the WorkspaceLayout (& thus Sidebar) was not loaded in the DatasetLayout pages

### DIFF
--- a/src/datasets/layouts/DatasetLayout.tsx
+++ b/src/datasets/layouts/DatasetLayout.tsx
@@ -19,6 +19,8 @@ import {
 } from "./DatasetLayout.generated";
 import LinkTabs from "core/components/Tabs/LinkTabs";
 import { trackEvent } from "core/helpers/analytics";
+import { CustomApolloClient } from "core/helpers/apollo";
+import { GetServerSidePropsContext } from "next";
 
 type DatasetLayoutProps = {
   datasetLink: DatasetLayout_DatasetLinkFragment;
@@ -234,6 +236,13 @@ DatasetLayout.fragments = {
     }
     ${DatasetVersionPicker.fragments.version}
   `,
+};
+
+DatasetLayout.prefetch = async (
+  ctx: GetServerSidePropsContext,
+  client: CustomApolloClient,
+) => {
+  await WorkspaceLayout.prefetch(ctx, client);
 };
 
 export default DatasetLayout;

--- a/src/pages/workspaces/[workspaceSlug]/datasets/[datasetSlug]/access.tsx
+++ b/src/pages/workspaces/[workspaceSlug]/datasets/[datasetSlug]/access.tsx
@@ -82,6 +82,7 @@ WorkspaceDatasetAccessPage.getLayout = (page) => page;
 export const getServerSideProps = createGetServerSideProps({
   requireAuth: true,
   async getServerSideProps(ctx, client) {
+    await DatasetLayout.prefetch(ctx, client);
     const versionId = (ctx.query.version as string) ?? "";
 
     const variables = {

--- a/src/pages/workspaces/[workspaceSlug]/datasets/[datasetSlug]/files/[[...fileId]].tsx
+++ b/src/pages/workspaces/[workspaceSlug]/datasets/[datasetSlug]/files/[[...fileId]].tsx
@@ -1,5 +1,3 @@
-import clsx from "clsx";
-import Overflow from "core/components/Overflow";
 import Page from "core/components/Page";
 import { createGetServerSideProps } from "core/helpers/page";
 import { NextPageWithLayout } from "core/helpers/types";
@@ -93,6 +91,7 @@ WorkspaceDatasetFilesPage.getLayout = (page) => page;
 export const getServerSideProps = createGetServerSideProps({
   requireAuth: true,
   async getServerSideProps(ctx, client) {
+    await DatasetLayout.prefetch(ctx, client);
     const versionId = (ctx.query.version as string) ?? "";
 
     const variables = {

--- a/src/pages/workspaces/[workspaceSlug]/datasets/[datasetSlug]/index.tsx
+++ b/src/pages/workspaces/[workspaceSlug]/datasets/[datasetSlug]/index.tsx
@@ -155,6 +155,7 @@ WorkspaceDatasetPage.getLayout = (page) => page;
 export const getServerSideProps = createGetServerSideProps({
   requireAuth: true,
   async getServerSideProps(ctx, client) {
+    await DatasetLayout.prefetch(ctx, client);
     const versionId = (ctx.query.version as string) ?? "";
 
     const variables = {


### PR DESCRIPTION
When the sidebar is in "compact mode", a hard reload on the a dataset page throw an hydration error. The cause is the lack of data fetched on the server that brings differences between the dom on the server & the client.

## How/what to test

- Put the sidebar in compact mode, reload the index page of a dataset in dev. No error should be thrown

