### PR TITLE
fix: Glitch when opening, choosing a tab and then closing the pipeline create dialog with feature flag enabled

### DIFF
--- a/src/workspaces/features/CreatePipelineDialog/CreatePipelineDialog.tsx
+++ b/src/workspaces/features/CreatePipelineDialog/CreatePipelineDialog.tsx
@@ -117,7 +117,7 @@ const CreatePipelineDialog = (props: CreatePipelineDialogProps) => {
     <Dialog open={open} onClose={onClose} maxWidth="max-w-4xl">
       <Dialog.Title>{t("How to create a pipeline")}</Dialog.Title>
       <Dialog.Content className="space-y-4">
-        <Tabs onChange={(index) => setTabIndex(index)}>
+        <Tabs onChange={(index) => setTabIndex(index)} defaultIndex={tabIndex}>
           {pipelineTemplateFeatureEnabled && (
             <Tabs.Tab label={t("From Template")} className={"space-y-2 pt-2"}>
               <PipelineTemplates workspace={workspace} showCard={false} />


### PR DESCRIPTION
The selected tab is reset but not the state of the component, causing a visual glitch when the template pipeline feature is enabled

## Changes

- Wire the selected tab