### PR TITLE
fix: handle gracefully duplicate template name (HEXA-1199)

### DIFF
--- a/public/locales/en/messages.json
+++ b/public/locales/en/messages.json
@@ -13,6 +13,7 @@
   "A new code has been sent to your mailbox.": "A new code has been sent to your mailbox.",
   "A pipeline with the same name already exists.": "A pipeline with the same name already exists.",
   "A pipeline with the selected notebook already exist": "A pipeline with the selected notebook already exist",
+  "A template with the same name already exists.": "A template with the same name already exists.",
   "About connections": "About connections",
   "About datasets": "About datasets",
   "About pipelines": "About pipelines",

--- a/public/locales/fr/messages.json
+++ b/public/locales/fr/messages.json
@@ -15,6 +15,7 @@
   "A new code has been sent to your mailbox.": "Un nouveau code a été envoyé à votre adresse e-mail.",
   "A pipeline with the same name already exists.": "Un pipeline portant le même nom existe déjà.",
   "A pipeline with the selected notebook already exist": "Un pipeline avec le carnet sélectionné existe déjà",
+  "A template with the same name already exists.": "Un modèle portant le même nom existe déjà.",
   "About connections": "A propos des connexions",
   "About datasets": "À propos des ensembles de données",
   "About pipelines": "À propos des pipelines",

--- a/schema.graphql
+++ b/schema.graphql
@@ -791,6 +791,8 @@ enum CreatePipelineTemplateVersionError {
   WORKSPACE_NOT_FOUND
   PIPELINE_NOT_FOUND
   PIPELINE_VERSION_NOT_FOUND
+  DUPLICATE_TEMPLATE_NAME_OR_CODE
+  UNKNOWN_ERROR
 }
 
 """Represents the input for creating a new pipeline template version."""

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -816,9 +816,11 @@ export type CreatePipelineResult = {
 
 /** Enum representing the possible errors that can occur when creating a pipeline template version. */
 export enum CreatePipelineTemplateVersionError {
+  DuplicateTemplateNameOrCode = 'DUPLICATE_TEMPLATE_NAME_OR_CODE',
   PermissionDenied = 'PERMISSION_DENIED',
   PipelineNotFound = 'PIPELINE_NOT_FOUND',
   PipelineVersionNotFound = 'PIPELINE_VERSION_NOT_FOUND',
+  UnknownError = 'UNKNOWN_ERROR',
   WorkspaceNotFound = 'WORKSPACE_NOT_FOUND'
 }
 

--- a/src/pipelines/features/PublishPipelineDialog/PublishPipelineDialog.tsx
+++ b/src/pipelines/features/PublishPipelineDialog/PublishPipelineDialog.tsx
@@ -87,6 +87,12 @@ const PublishPipelineDialog = ({
         )
       ) {
         toast.error(t("You are not allowed to create a Template."));
+      } else if (
+        data.createPipelineTemplateVersion.errors?.includes(
+          CreatePipelineTemplateVersionError.DuplicateTemplateNameOrCode,
+        )
+      ) {
+        toast.error(t("A template with the same name already exists."));
       } else {
         toast.error(t("Unknown error."));
       }


### PR DESCRIPTION
Cast duplicate error and show a message