### PR TITLE
fix: the sidebar pipelines tab is not marked as active when the user is in the templates pages (HEXA-1189)

### DIFF
--- a/src/workspaces/layouts/WorkspaceLayout/Sidebar.test.tsx
+++ b/src/workspaces/layouts/WorkspaceLayout/Sidebar.test.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { MemoryRouterProvider } from "next-router-mock/MemoryRouterProvider";
+import mockRouter from "next-router-mock";
+import { LayoutContext } from "./WorkspaceLayout";
+import Sidebar from "./Sidebar";
+import { Sidebar_WorkspaceFragment } from "./Sidebar.generated";
+import { TestApp } from "core/helpers/testutils";
+
+const mockWorkspace: Sidebar_WorkspaceFragment = {
+  slug: "test-workspace",
+  name: "Test Workspace",
+  countries: [
+    { __typename: "Country", flag: "🇺🇸", code: "US" },
+    { __typename: "Country", flag: "🇨🇦", code: "CA" },
+  ],
+  permissions: {
+    manageMembers: true,
+    update: true,
+    launchNotebookServer: true,
+  },
+  __typename: "Workspace",
+};
+
+describe("Sidebar", () => {
+  it("should highlight the current link", () => {
+    mockRouter.setCurrentUrl("/workspaces/test-workspace");
+    const { getByText } = render(
+      <MemoryRouterProvider>
+        <TestApp>
+          <LayoutContext.Provider
+            value={{ isSidebarOpen: true, setSidebarOpen: jest.fn() }}
+          >
+            <Sidebar workspace={mockWorkspace} />
+          </LayoutContext.Provider>
+        </TestApp>
+      </MemoryRouterProvider>,
+    );
+
+    const homeLink = getByText("Home");
+    expect(homeLink).toHaveClass("text-white");
+  });
+
+  it("should highlight the pipelines link when on templates path", () => {
+    mockRouter.setCurrentUrl("/workspaces/test-workspace/templates");
+
+    const { getByText } = render(
+      <MemoryRouterProvider>
+        <TestApp>
+          <LayoutContext.Provider
+            value={{ isSidebarOpen: true, setSidebarOpen: jest.fn() }}
+          >
+            <Sidebar workspace={mockWorkspace} />
+          </LayoutContext.Provider>
+        </TestApp>
+      </MemoryRouterProvider>,
+    );
+
+    const pipelinesLink = getByText("Pipelines");
+    expect(pipelinesLink).toHaveClass("text-white");
+  });
+});

--- a/src/workspaces/layouts/WorkspaceLayout/Sidebar.tsx
+++ b/src/workspaces/layouts/WorkspaceLayout/Sidebar.tsx
@@ -75,7 +75,7 @@ const Sidebar = (props: SidebarProps) => {
   const { slug } = workspace;
 
   const homeLink = {
-    href: `/workspaces/${encodeURIComponent(slug)}/`,
+    href: `/workspaces/${encodeURIComponent(slug)}`,
     label: t("Home"),
     Icon: HomeIcon,
   };
@@ -140,7 +140,7 @@ const Sidebar = (props: SidebarProps) => {
     ) {
       return pipelineLink.href;
     }
-    if (router.asPath === homeLink.href) {
+    if (router.asPath.startsWith(homeLink.href)) {
       return homeLink.href;
     }
   }, [router.asPath]);
@@ -152,13 +152,13 @@ const Sidebar = (props: SidebarProps) => {
 
         <div className="mt-5 flex grow flex-col">
           <nav className="flex-1 space-y-1 px-0 pb-4">
-            {[homeLink].concat(links).map((link) => (
+            {[homeLink].concat(links).map(({ href, Icon, label }) => (
               <NavItem
-                key={link.href}
-                href={link.href}
-                Icon={link.Icon}
-                label={link.label}
-                isCurrent={currentLink === link.href}
+                key={href}
+                href={href}
+                Icon={Icon}
+                label={label}
+                isCurrent={currentLink === href}
                 compact={!isSidebarOpen}
               />
             ))}

--- a/src/workspaces/layouts/WorkspaceLayout/Sidebar.tsx
+++ b/src/workspaces/layouts/WorkspaceLayout/Sidebar.tsx
@@ -16,11 +16,11 @@ import Badge from "core/components/Badge";
 import Link from "core/components/Link";
 import { CustomApolloClient } from "core/helpers/apollo";
 import { useTranslation } from "next-i18next";
-import { useRouter } from "next/router";
 import { useContext, useMemo } from "react";
 import SidebarMenu from "workspaces/features/SidebarMenu";
 import { Sidebar_WorkspaceFragment } from "./Sidebar.generated";
 import { LayoutContext } from "./WorkspaceLayout";
+import { useRouter } from "next/router";
 
 type SidebarProps = {
   workspace: Sidebar_WorkspaceFragment;
@@ -31,23 +31,10 @@ const NavItem = (props: {
   Icon: any;
   label?: string;
   href: string;
-  exact?: boolean;
+  isCurrent: boolean;
   compact?: boolean;
 }) => {
-  const { Icon, compact, label, href, exact } = props;
-  const router = useRouter();
-
-  const isCurrent = useMemo(() => {
-    if (!exact && router.asPath.startsWith(href)) {
-      return true;
-    }
-
-    if (exact && router.asPath === href) {
-      return true;
-    }
-
-    return false;
-  }, [href, exact, router.asPath]);
+  const { Icon, compact, label, href, isCurrent } = props;
 
   return (
     <Link
@@ -83,8 +70,80 @@ const Sidebar = (props: SidebarProps) => {
   const { workspace, className } = props;
   const { t } = useTranslation();
   const { isSidebarOpen, setSidebarOpen } = useContext(LayoutContext);
+  const router = useRouter();
 
   const { slug } = workspace;
+
+  const homeLink = {
+    href: `/workspaces/${encodeURIComponent(slug)}/`,
+    label: t("Home"),
+    Icon: HomeIcon,
+  };
+  const pipelineLink = {
+    href: `/workspaces/${encodeURIComponent(slug)}/pipelines`,
+    label: t("Pipelines"),
+    Icon: BoltIcon,
+  };
+
+  const links = [
+    {
+      href: `/workspaces/${encodeURIComponent(slug)}/files`,
+      label: t("Files"),
+      Icon: FolderOpenIcon,
+    },
+    {
+      href: `/workspaces/${encodeURIComponent(slug)}/databases`,
+      label: t("Database"),
+      Icon: CircleStackIcon,
+    },
+    {
+      href: `/workspaces/${encodeURIComponent(slug)}/datasets`,
+      label: t("Datasets"),
+      Icon: Square2StackIcon,
+    },
+    {
+      href: `/workspaces/${encodeURIComponent(slug)}/connections`,
+      label: t("Connections"),
+      Icon: SwatchIcon,
+    },
+    pipelineLink,
+    ...(workspace.permissions.launchNotebookServer
+      ? [
+          {
+            href: `/workspaces/${encodeURIComponent(slug)}/notebooks`,
+            label: t("JupyterHub"),
+            Icon: BookOpenIcon,
+          },
+        ]
+      : []),
+    ...(workspace.permissions.manageMembers
+      ? [
+          {
+            href: `/workspaces/${encodeURIComponent(slug)}/settings`,
+            label: t("Settings"),
+            Icon: Cog6ToothIcon,
+          },
+        ]
+      : []),
+  ];
+
+  const currentLink = useMemo(() => {
+    for (const { href } of links) {
+      if (router.asPath.startsWith(href)) {
+        return href;
+      }
+    }
+    if (
+      router.asPath.startsWith(
+        `/workspaces/${encodeURIComponent(slug)}/templates`,
+      )
+    ) {
+      return pipelineLink.href;
+    }
+    if (router.asPath === homeLink.href) {
+      return homeLink.href;
+    }
+  }, [router.asPath]);
 
   return (
     <div className={clsx("relative z-20 flex h-full flex-col", className)}>
@@ -93,59 +152,16 @@ const Sidebar = (props: SidebarProps) => {
 
         <div className="mt-5 flex grow flex-col">
           <nav className="flex-1 space-y-1 px-0 pb-4">
-            <NavItem
-              exact
-              href={`/workspaces/${encodeURIComponent(slug)}/`}
-              Icon={HomeIcon}
-              label={t("Home")}
-              compact={!isSidebarOpen}
-            />
-            <NavItem
-              href={`/workspaces/${encodeURIComponent(slug)}/files`}
-              Icon={FolderOpenIcon}
-              label={t("Files")}
-              compact={!isSidebarOpen}
-            />
-            <NavItem
-              href={`/workspaces/${encodeURIComponent(slug)}/databases`}
-              Icon={CircleStackIcon}
-              label={t("Database")}
-              compact={!isSidebarOpen}
-            />
-            <NavItem
-              href={`/workspaces/${encodeURIComponent(slug)}/datasets`}
-              Icon={Square2StackIcon}
-              label={t("Datasets")}
-              compact={!isSidebarOpen}
-            />
-            <NavItem
-              href={`/workspaces/${encodeURIComponent(slug)}/connections`}
-              Icon={SwatchIcon}
-              label={t("Connections")}
-              compact={!isSidebarOpen}
-            />
-            <NavItem
-              href={`/workspaces/${encodeURIComponent(slug)}/pipelines`}
-              Icon={BoltIcon}
-              label={t("Pipelines")}
-              compact={!isSidebarOpen}
-            />
-            {workspace.permissions.launchNotebookServer && (
+            {[homeLink].concat(links).map((link) => (
               <NavItem
-                href={`/workspaces/${encodeURIComponent(slug)}/notebooks`}
-                Icon={BookOpenIcon}
-                label={t("JupyterHub")}
+                key={link.href}
+                href={link.href}
+                Icon={link.Icon}
+                label={link.label}
+                isCurrent={currentLink === link.href}
                 compact={!isSidebarOpen}
               />
-            )}
-            {workspace.permissions.manageMembers && (
-              <NavItem
-                href={`/workspaces/${encodeURIComponent(slug)}/settings`}
-                Icon={Cog6ToothIcon}
-                label={t("Settings")}
-                compact={!isSidebarOpen}
-              />
-            )}
+            ))}
           </nav>
         </div>
 


### PR DESCRIPTION
Refactor the `NavItem` to accept a `isCurrent` prop and moving the `isCurrent` logic into the parent

## Changes

- Refactor
- 2 unit tests to cover the edge cases

## How/what to test

Navigating the website correctly shows the active navigation item