### PR TITLE
fix: Cannot edit dataset metadata (absolute button without z index) (HEXA-1210)

### DIFF
--- a/src/core/components/DataCard/FormSection.tsx
+++ b/src/core/components/DataCard/FormSection.tsx
@@ -221,7 +221,9 @@ function FormSection<F extends { [key: string]: any }>(
         {() => (
           <>
             {!title && (
-              <div className="absolute top-0 right-0">{renderEditButton()}</div>
+              <div className="absolute top-0 right-0 z-1">
+                {renderEditButton()}
+              </div>
             )}
             {isEdited ? (
               <form onSubmit={form.handleSubmit}>

--- a/src/core/components/DataCard/__tests__/__snapshots__/DataCard.test.tsx.snap
+++ b/src/core/components/DataCard/__tests__/__snapshots__/DataCard.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`DataCard renders 1`] = `
             id="headlessui-disclosure-panel-b0421256-86a3-4e0a-9682-3cf5bee102e1"
           >
             <div
-              class="absolute top-0 right-0"
+              class="absolute top-0 right-0 z-1"
             />
             <dl
               class="grid gap-4"


### PR DESCRIPTION
The dataset button is positioned using absolute but no z-index is specified, resulting in it rendered behind the description text and not clickable.

## Changes

- Add a z-index (I have tried to render it without an absolute to avoid usage of z-index but it takes unnecessary space so I fell back to z-index)

## How/what to test

Editing the dataset general section is possible